### PR TITLE
Add 1Password Teams for Open Source

### DIFF
--- a/content/library/resources.json
+++ b/content/library/resources.json
@@ -24,7 +24,7 @@
             "type": "Talks",
             "topics": "Scaling, Contributor Relations, Metrics"
         },
-         {
+        {
             "title": "CNCF Maintainer Guide",
             "author": "CNCF",
             "description": "",
@@ -40,7 +40,7 @@
             "type": "Guide",
             "topics": "Open Source, Governance, Licenses"
         },
-          {
+        {
             "title": "Quick links on contributor strategies",
             "author": "CNCF",
             "description": "A series of links to resources frequently used by the Contributor Strategy TAG",
@@ -57,20 +57,28 @@
             "topics": "Open Source, Funding, Hiring, Grants, Budgeting"
         },
         {
-  "title": "The 2021 Tidelift open source maintainer survey",
-  "author": "Tidelift",
-  "description": "In early 2021, Tidelift fielded its first-ever comprehensive survey of open source maintainers.",
-  "link": "https://tidelift.com/subscription/the-tidelift-maintainer-survey",
-  "type": "Guide",
-  "topics": "Maintainers, Open Source, Survey, Data"
+            "title": "The 2021 Tidelift open source maintainer survey",
+            "author": "Tidelift",
+            "description": "In early 2021, Tidelift fielded its first-ever comprehensive survey of open source maintainers.",
+            "link": "https://tidelift.com/subscription/the-tidelift-maintainer-survey",
+            "type": "Guide",
+            "topics": "Maintainers, Open Source, Survey, Data"
         },
         {
-  "title": "The 2022 open source software supply chain survey ",
-  "author": "Tidelift",
-  "description": "In December of 2021, Tidelift fielded our annual survey of technologists—including software devs, engineering execs and managers, architects, and devops pros—who build applications with open source.",
-  "link": "https://tidelift.com/2022-open-source-software-supply-chain-survey",
-  "type": "Guide",
-  "topics": "Open Source, Survey, Data"
-}
+            "title": "The 2022 open source software supply chain survey ",
+            "author": "Tidelift",
+            "description": "In December of 2021, Tidelift fielded our annual survey of technologists—including software devs, engineering execs and managers, architects, and devops pros—who build applications with open source.",
+            "link": "https://tidelift.com/2022-open-source-software-supply-chain-survey",
+            "type": "Guide",
+            "topics": "Open Source, Survey, Data"
+        },
+        {
+            "title": "1Password Teams for Open Source",
+            "author": "1Password",
+            "description": "Get a free 1Password Teams membership for your open source project",
+            "link": "https://github.com/1password/1password-teams-open-source",
+            "type": "Resource",
+            "topics": "Open Source, Software, Password Management"
+        }
     ]
 }


### PR DESCRIPTION
<img width="1764" alt="image" src="https://user-images.githubusercontent.com/6097064/167606148-eaeae77a-5a39-4aeb-b230-d449d2cccd63.png">

Adds 1Password Teams for Open Source to the Library section. This is a program we run where maintainers of open source projects can claim a free account to help them with sharing credentials associated with the project.

I also noticed a few indentation issues from a previous commit so I fixed those - hope that's ok!