### PR TITLE
fix url link

### DIFF
--- a/content/events/osworkshop-1.md
+++ b/content/events/osworkshop-1.md
@@ -8,7 +8,7 @@ UTCEndTime: '20:30'
 type: 'meetup'
 userName: 'github'
 userLink: 'https://maintainers.github.com'
-linkUrl: 'https:/maintainers.github.com'
+linkUrl: 'https://maintainers.github.com'
 ---
 
 In this 90-minute interactive workshop, maintainers will share their experiences and learn about frameworks around the contributor life-cycle. We’ll document and share best practices to help other maintainers onboard new contributors and invest in new maintainers.

--- a/content/events/osworkshop-2.md
+++ b/content/events/osworkshop-2.md
@@ -8,7 +8,7 @@ UTCEndTime: '24:30'
 type: 'meetup'
 userName: 'github'
 userLink: 'https://maintainers.github.com'
-linkUrl: 'https:/maintainers.github.com'
+linkUrl: 'https://maintainers.github.com'
 ---
 
 In this 90-minute interactive workshop, maintainers will share their experiences and learn about frameworks around the contributor life-cycle. We’ll document and share best practices to help other maintainers onboard new contributors and invest in new maintainers.


### PR DESCRIPTION
The workshops use a broken url due to a missing **/**.

By clicking on the link to the meetup from the workshop detail page, it targets `https://maintainermonth.github.com/maintainers.github.com`, ending on the error page:

<img width="579" alt="image" src="https://github.com/github/maintainermonth/assets/32737308/fb757adb-9f25-426f-9fd9-3a7bb0961885">
