### PR TITLE
Fixed links in `osworkshop-1.md` and `osworkshop-2.md`

### DIFF
--- a/content/events/osworkshop-1.md
+++ b/content/events/osworkshop-1.md
@@ -13,4 +13,4 @@ linkUrl: 'https://maintainers.github.com'
 
 In this 90-minute interactive workshop, maintainers will share their experiences and learn about frameworks around the contributor life-cycle. We’ll document and share best practices to help other maintainers onboard new contributors and invest in new maintainers.
 
-Workshop registration is available in the private Maintainer Community. Request and invitation here: https:/maintainers.github.com
+Workshop registration is available in the private Maintainer Community. Request and invitation here: https://maintainers.github.com

--- a/content/events/osworkshop-2.md
+++ b/content/events/osworkshop-2.md
@@ -13,4 +13,4 @@ linkUrl: 'https://maintainers.github.com'
 
 In this 90-minute interactive workshop, maintainers will share their experiences and learn about frameworks around the contributor life-cycle. We’ll document and share best practices to help other maintainers onboard new contributors and invest in new maintainers.
 
-Workshop registration is available in the private Maintainer Community. Request and invitation here: https:/maintainers.github.com
+Workshop registration is available in the private Maintainer Community. Request and invitation here: https://maintainers.github.com


### PR DESCRIPTION
Fixed links in `osworkshop-1.md` and `osworkshop-2.md`, they were missing a `/` :)