### PR TITLE
fix: Typo for the word "Maintainer"

### DIFF
--- a/content/library/resources.json
+++ b/content/library/resources.json
@@ -22,7 +22,7 @@
             "description": "Special for Maintainer Month, Ayu shares their journey and experience from being a contributor to a maintainer, the ups and downs, and the joy of being a maintainer",
             "link": "https://adiati.com/from-contributor-to-maintainer-my-journey-in-open-source",
             "type": "Blog",
-            "topics": "Mainatiner"
+            "topics": "Maintainer"
         },
         {
             "title": "Maintainer Burnout is a Problem. So, What Are We Going to Do About It?",


### PR DESCRIPTION
## Description

Based on [this comment](https://github.com/github/maintainermonth/issues/186#issuecomment-2813847556), this PR fixes the typo and changes "Mainatiner" to "Maintainer".

## Link issue

Relates to #186 