### PR TITLE
fix: Blog title for Chrissy Codes

### DIFF
--- a/content/library/resources.json
+++ b/content/library/resources.json
@@ -97,7 +97,7 @@
             "topics": "SurrealDB"
         },
         {
-            "title": "Chrissy Codes",
+            "title": "4 Tips to Transition from Contributorhood to Maintainership",
             "author": "Chrissy Codes",
             "description": "",
             "link": "https://chrissycodes.hashnode.dev/4-tips-to-transition-from-contributorhood-to-maintainership",


### PR DESCRIPTION
## Description

This PR changes the title for Chrissy Codes from "Chrissy Codes" to "4 Tips to Transition from Contributorhood to Maintainership".

## Link issue

Fixes #257 