### PR TITLE
Fix position of 'Add your own activity' button

### DIFF
--- a/components/events-list/EventsList.jsx
+++ b/components/events-list/EventsList.jsx
@@ -68,8 +68,7 @@ const EventsList = ({ events }) => {
           </div>
         </div>
       ))}
-      <br />
-      <div>
+      <div className="events-list__add">
         <ButtonLink href="https://github.com/github/maintainermonth/issues/new?assignees=&labels=&template=add-to-calendar.yml&title=EVENT_NAME">
           Add your own activity
         </ButtonLink>

--- a/components/events-list/events-list.scss
+++ b/components/events-list/events-list.scss
@@ -134,4 +134,10 @@
     line-clamp: 7;
     -webkit-box-orient: vertical;
   }
+
+  &__add {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 }

--- a/components/events-list/events-list.scss
+++ b/components/events-list/events-list.scss
@@ -9,14 +9,47 @@
 
   @media (min-width: $md) {
     grid-template-columns: repeat(2, 1fr);
+
+    > :last-child:nth-child(2n + 1) {
+      grid-column: span 2;
+    }
+    > :last-child:nth-child(2n + 2) {
+      grid-column: span 1;
+    }
+    > :last-child:nth-child(2n + 3) {
+      grid-column: span 2;
+    }
   }
 
   @media (min-width: $lg) {
     grid-template-columns: repeat(3, 1fr);
+
+    > :last-child:nth-child(3n + 1) {
+      grid-column: span 3;
+    }
+    > :last-child:nth-child(3n + 2) {
+      grid-column: span 2;
+    }
+    > :last-child:nth-child(3n + 3) {
+      grid-column: span 1;
+    }
   }
 
   @media (min-width: $xl) {
     grid-template-columns: repeat(4, 1fr);
+
+    /* These classes will fix the add activity button position
+     * as long as the button is the last child in the grid
+     */
+    > :last-child:nth-child(4n + 1) {
+      grid-column: span 4;
+    }
+    > :last-child:nth-child(4n + 2) {
+      grid-column: span 3;
+    }
+    > :last-child:nth-child(4n + 3) {
+      grid-column: span 2;
+    }
   }
 
   &__card {
@@ -135,6 +168,7 @@
     -webkit-box-orient: vertical;
   }
 
+  /* Add your own activity button */
   &__add {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Addresses #252 

## Before:

The add button is directly below the previous grid row in a non-obvious position.


<details><summary>Screenshot</summary>
<p>

![image](https://github.com/user-attachments/assets/c4c96e0a-5574-499a-91bf-e69066738654)

</p>
</details> 

## After:

The button will be centered in the remaining space of the grid row, or take up the full width of the last row if the current row is full. It is responsive and easy to find.

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/user-attachments/assets/19974013-0158-458e-bf29-a4844d74a161)

</p>
</details> 

**Other options:**
I could also put the button in a column next to the last card. Do you think this or the centered version (in the `After` section above) looks better?

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/user-attachments/assets/d65370b0-9de8-4271-9273-64c2ab9464aa)

</p>
</details>

Be sure to tell me if there are any changes you want!