### PR TITLE
Add event button classname is not applied

### DIFF
--- a/components/button-link/ButtonLink.jsx
+++ b/components/button-link/ButtonLink.jsx
@@ -1,13 +1,14 @@
 import Link from 'next/link'
 import IconArrowRight from '../../public/icons/arrow-right'
+import clsx from 'clsx'
 
-const ButtonLink = ({ href, isExternal, children }) => {
+const ButtonLink = ({ href, isExternal, children, className }) => {
   return (
     <Link
       href={href}
       target={isExternal ? '_blank' : undefined}
       rel={isExternal ? 'noreferrer' : undefined}
-      className="button-link"
+      className={clsx('button-link', className)}
     >
       {children} <IconArrowRight />
     </Link>

--- a/components/button-link/button-link.scss
+++ b/components/button-link/button-link.scss
@@ -30,6 +30,7 @@
     background: $white;
     color: $purple;
     font-weight: 600;
+    margin-top: spacing(1);
 
     svg path {
       fill: $purple;

--- a/components/button-link/button-link.scss
+++ b/components/button-link/button-link.scss
@@ -18,6 +18,7 @@
 
   svg path {
     transition: fill 0.2s ease;
+    fill: $white;
   }
 
   &:hover svg path {


### PR DESCRIPTION
## Before

@AndreaGriffiths11 Made the events grid so much prettier :star_struck: 

However, there are a couple of things I noticed:

1. The icon on button links is black (this is an issue with all the button links).
2. The margin between the text and button seems to be less than the text line-height (a picky little thing).

![image](https://github.com/user-attachments/assets/244c358a-d2f3-4135-baa6-bddff2aa9526)

In the process of messing with this, I discovered a third thing. There are classes that are not applied because, while the `className` prop was passed to the button link, the button link doesn't accept a `className` prop and so it is never applied.

## After

Will all fixes applied, the new section looks like this:

![image](https://github.com/user-attachments/assets/50e3404f-7c44-4609-ab2f-c2c63b2b144d)

The button is white due to changes made in PR #260 by @AndreaGriffiths11. See the specific diff here:
https://github.com/github/maintainermonth/pull/260/files#diff-da275896c80ebad87819e008c15b36a54697e45dfe79e5d4f61f205365b66c6dR27
I could revert this if you think it would look better the other way.

Other button links look the same as before but with the correct icon color. Example:

**Before:**
![image](https://github.com/user-attachments/assets/cf6ce358-f4f2-4749-a235-bed5b8a9079e)

**After:**
![image](https://github.com/user-attachments/assets/c0846f7c-cb50-4ed7-8c46-5093a5c1d5a6)

----

I'm sure you can think of plenty of changes to make, please give feedback! :heart: 

I also have a question for the maintainers. What is the contributing process? Should contributors always create an issue before making a PR, or can they just make a PR (like I just did :flushed:)? Thanks!