### PR TITLE
fix: Change event labels' background color

### DIFF
--- a/components/event-type-chip/types.js
+++ b/components/event-type-chip/types.js
@@ -12,7 +12,7 @@ const TYPES = {
   podcast: {
     label: getLiteral('event-type:podcast'),
     icon: <IconPodcast />,
-    color: '#FA0087',
+    color: '#E6007A',
   },
   stream: {
     label: getLiteral('event-type:stream'),
@@ -22,12 +22,12 @@ const TYPES = {
   talk: {
     label: getLiteral('event-type:talk'),
     icon: <IconTalk />,
-    color: '#1FD19F',
+    color: '#138162',
   },
   meetup: {
     label: getLiteral('event-type:meetup'),
     icon: <IconMeetup />,
-    color: '#F42F36',
+    color: '#C70A11',
   },
   fundraising: {
     label: getLiteral('event-type:fundraising'),


### PR DESCRIPTION
## Description

This PR changes the background color of some labels to pass color checker for accessibility improvement with details as follow:

- Red for the "Meetup" type: `#F42F36` to `#C70A11`
- Pink for the "Podcast" type: `#FA0087` to `#E6007A`
- Green for the "Talk" type: `#1FD19F` to `#138162`

### Screenshots & screen recording

![zero color contrast error summary](https://github.com/user-attachments/assets/d2295c25-378a-45b2-ad39-5d45dc7cd4b8)

https://github.com/user-attachments/assets/f12a7a5e-19b3-4c90-a83f-b9451902c99f

## Linked issue

Fixes #274 

