### PR TITLE
feat: add CODEOWNERS file to define default reviewers for the repository

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @karasowles, @andreagriffiths, @ladykerr, and @cassidoo will be requested for
+# @karasowles, @AndreaGriffiths11, @ladykerr, and @cassidoo will be requested for
 # review when someone opens a pull request.
-*       @karasowles @andreagriffiths @ladykerr @cassidoo
+*       @karasowles @AndreaGriffiths11 @ladykerr @cassidoo

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @karasowles, @andreagriffiths, @ladykerr, and @cassidoo will be requested for
+# review when someone opens a pull request.
+*       @karasowles @andreagriffiths @ladykerr @cassidoo


### PR DESCRIPTION
This pull request updates the `CODEOWNERS` file to define default code owners for the repository.

* [`CODEOWNERS`](diffhunk://#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bR1-R5): Added default owners (`@karasowles`, `@andreagriffiths`, `@ladykerr`, and `@cassidoo`) who will automatically be requested for review on pull requests unless overridden by more specific rules.