### PR TITLE
Allow events to have a "TBD" or "All Day" time

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-to-calendar.yml
+++ b/.github/ISSUE_TEMPLATE/add-to-calendar.yml
@@ -1,13 +1,13 @@
 name: 💁🏽‍♀️ Add an event for maintainers to the calendar 🎙
 description: Use this form to add an event for maintainers or highlighting maintainers to the Maintainer Month calendar.
-title: "EVENT_NAME"
+title: 'EVENT_NAME'
 
 body:
   - type: markdown
     attributes:
       value: |
         :tada: Thanks for letting us know about an upcoming event! :tada:
-        
+
         Use this form to add an event for maintainers or highlighting maintainers to the Maintainer Month calendar. Your request will be reviewed within 72 hours.
 
   - id: eventname
@@ -16,20 +16,28 @@ body:
       label: Event Name
     validations:
       required: true
-      
+
   - id: date
     type: input
     attributes:
       label: Event Date
-      placeholder: "MM/DD"
+      placeholder: 'MM/DD'
     validations:
       required: true
+
+  - id: endDate
+    type: input
+    attributes:
+      label: Event End Date
+      placeholder: 'MM/DD'
+    validations:
+      required: false
 
   - id: UTCStartTime
     type: input
     attributes:
       label: Start time in UTC
-      placeholder: "14:00"
+      placeholder: '14:00'
     validations:
       required: true
 
@@ -37,7 +45,7 @@ body:
     type: input
     attributes:
       label: End time in UTC
-      placeholder: "15:00"
+      placeholder: '15:00'
     validations:
       required: true
 
@@ -45,7 +53,7 @@ body:
     type: dropdown
     attributes:
       label: Event Type
-      description: "Type of event"
+      description: 'Type of event'
       options:
         - conference
         - podcast
@@ -61,7 +69,7 @@ body:
     type: input
     attributes:
       label: Event Language
-      description: "Primary language of the event (e.g., English, Spanish, Mandarin)"
+      description: 'Primary language of the event (e.g., English, Spanish, Mandarin)'
     validations:
       required: true
 
@@ -69,7 +77,7 @@ body:
     type: input
     attributes:
       label: Event Location
-      description: "Primary location of the event - either Virtual or a City + Country"
+      description: 'Primary location of the event - either Virtual or a City + Country'
     validations:
       required: true
 
@@ -85,25 +93,25 @@ body:
     type: input
     attributes:
       label: Event URL
-      description: "Web URL of event"
-      placeholder: "https://"
+      description: 'Web URL of event'
+      placeholder: 'https://'
 
   - id: eventdescription
     type: textarea
     attributes:
       label: Event Description
-      description: "What is this event about?"
-  
+      description: 'What is this event about?'
+
   - id: expectedparticipants
     type: input
     attributes:
       label: Participants
-      description: "Expected number of participants"
-      placeholder: "###"
-  
+      description: 'Expected number of participants'
+      placeholder: '###'
+
   - id: expectedmaintainers
     type: input
     attributes:
       label: Maintainers
-      description: "Expected number of maintainers participating"
-      placeholder: "###"
+      description: 'Expected number of maintainers participating'
+      placeholder: '###'

--- a/components/events-list/EventsList.jsx
+++ b/components/events-list/EventsList.jsx
@@ -12,16 +12,20 @@ import DateTimeChip from '../date-time-chip/DateTimeChip'
 import EventTypeChip from '../event-type-chip/EventTypeChip'
 import PlayLink from '../play-link/PlayLink'
 import Chip from '../chip/Chip'
-
 const EventsList = ({ events }) => {
+  const dateLabel = (event) =>
+    `${event.formattedDate.date} to ${event.formattedDate.endDate}`
+
   return (
     <section className="events-list">
       <div className="events-list__header">
         <div className="events-list__header-content">
           <h1 className="events-list__title">{getLiteral('schedule:title')}</h1>
-          <p className="events-list__subtitle">{getLiteral('schedule:description')}</p>
-          <ButtonLink 
-            href="https://github.com/github/maintainermonth/issues/new?template=add-to-calendar.yml" 
+          <p className="events-list__subtitle">
+            {getLiteral('schedule:description')}
+          </p>
+          <ButtonLink
+            href="https://github.com/github/maintainermonth/issues/new?template=add-to-calendar.yml"
             isExternal={true}
             className="events-list__add-button"
           >
@@ -39,7 +43,11 @@ const EventsList = ({ events }) => {
             })}
           >
             <div className="events-list__date">
-              <Chip label={event.formattedDate.date} />
+              {event.formattedDate.endDate ? (
+                <Chip label={dateLabel(event)} />
+              ) : (
+                <Chip label={event.formattedDate.date} />
+              )}
             </div>
 
             <div className="events-list__event">
@@ -68,7 +76,7 @@ const EventsList = ({ events }) => {
               </div>
 
               <div className="events-list__info">
-                <p 
+                <p
                   className="events-list__text"
                   dangerouslySetInnerHTML={{
                     __html: md().render(event.description || ''),
@@ -80,7 +88,7 @@ const EventsList = ({ events }) => {
         ))}
       </div>
     </section>
-  );
-};
+  )
+}
 
-export default EventsList;
+export default EventsList

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -61,7 +61,7 @@ describe('Event files', () => {
     })
   })
 
-  test('An event with an invalid start time retunrs TBD', () => {
+  test('An event with an invalid start time returns TBD', () => {
     const event = testTypewindEvent
     const parsedEvent = parseEvent(event)
     expect(parsedEvent).toEqual(

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -1,6 +1,8 @@
 import fs from 'fs'
 
 import { getEventBySlug, parseEvent } from '../api/events'
+import testTypewindEvent from './testData/2025-05-02-typewind'
+import testCookieCutterEvent from './testData/2025-05-02-Cookie-Cutter'
 
 describe('Event files', () => {
   test('All event files have ".md" extension', () => {
@@ -23,5 +25,54 @@ describe('Event files', () => {
     events.forEach((event) => {
       expect(() => parseEvent(event)).not.toThrowError()
     })
+  })
+
+  test('An event has an end date and does not throw an error', () => {
+    const eventFiles = fs.readdirSync('content/events')
+
+    const events = eventFiles.map((fileName) => {
+      const slug = fileName.replace('.md', '')
+      const event = getEventBySlug(slug)
+      return event
+    })
+
+    events.forEach((event) => {
+      expect(() => parseEvent(event)).not.toThrowError()
+    })
+  })
+
+  test('An event returns an endDate', () => {
+    const event = testCookieCutterEvent
+    const parsedEvent = parseEvent(event)
+    expect(parsedEvent).toEqual(expect.objectContaining({ endDate: '07/02' }))
+  })
+
+  test('An event has an invalid start time and does not throw an error', () => {
+    const eventFiles = fs.readdirSync('content/events')
+
+    const events = eventFiles.map((fileName) => {
+      const slug = fileName.replace('.md', '')
+      const event = getEventBySlug(slug)
+      return event
+    })
+
+    events.forEach((event) => {
+      expect(() => parseEvent(event)).not.toThrowError()
+    })
+  })
+
+  test('An event with an invalid start time retunrs TBD', () => {
+    const event = testTypewindEvent
+    const parsedEvent = parseEvent(event)
+    expect(parsedEvent).toEqual(
+      expect.objectContaining({
+        formattedDate: expect.objectContaining({
+          startTime: {
+            pt: 'TBD',
+            utc: 'TBD',
+          },
+        }),
+      }),
+    )
   })
 })

--- a/tests/testData/2025-05-02-Cookie-Cutter.js
+++ b/tests/testData/2025-05-02-Cookie-Cutter.js
@@ -1,0 +1,25 @@
+const cookieCutterEvent = {
+  slug: '2025-05-02-Cookie-Cutter',
+  title: 'Open Source Friday Brasil: Cookie Cutter and FastAPI',
+  metaTitle: 'Open Source Friday Brasil: Cookie Cutter and FastAPI',
+  metaDesc:
+    'Join Arthur Henrique to discuss Cookiecutter template for FastAPI projects using Machine Learning, uv, GitHub Actions, and Pytests.',
+  date: '05/02',
+  endDate: '07/02',
+  UTCStartTime: '16:00',
+  UTCEndTime: '17:00',
+  type: 'stream',
+  location: 'Virtual',
+  language: 'Portuguese',
+  userName: 'GitHub',
+  userLink: 'https://www.youtube.com/github',
+  linkUrl: 'https://www.youtube.com/github',
+  content:
+    '\n' +
+    'Join [Arthur Henrique](https://github.com/arthurhenrique) to discuss Cookiecutter template for FastAPI projects using Machine Learning, uv, GitHub Actions, and Pytests.\n' +
+    '\n' +
+    "Open Source Fridays Brasil stream weekly on GitHub's [Twitch](https://www.twitch.tv/githubbrasil), [YouTube](https://github.com/youtube), and [LinkedIn](https://www.linkedin.com/company/githubbrasil).\n",
+  link: '/schedule/2025-05-02-Cookie-Cutter',
+}
+
+export default cookieCutterEvent

--- a/tests/testData/2025-05-02-typewind.js
+++ b/tests/testData/2025-05-02-typewind.js
@@ -1,0 +1,24 @@
+const typewindEvent = {
+  slug: '2025-05-02-typewind',
+  title: 'Open Source Friday: Typewind',
+  metaTitle: 'Open Source Friday: Typewind',
+  metaDesc:
+    'Chat with Mokshit Jain about Typewind, a build tool focused on improving web performance.',
+  date: '05/02',
+  UTCStartTime: 'G:00',
+  UTCEndTime: '7:00',
+  type: 'stream',
+  location: 'Virtual',
+  language: 'English',
+  userName: 'GitHub',
+  userLink: 'https://www.twitch.tv/github/schedule',
+  linkUrl: 'https://www.twitch.tv/github/schedule',
+  content:
+    '\n' +
+    'Chat with [Mokshit Jain](https://github.com/Mokshit06) about [Typewind](https://github.com/Mokshit06/typewind), a build tool focused on improving web performance. Explore the journey of creating Typewind and contributions to the open-source build-tools space.\n' +
+    '\n' +
+    "[Open Source Fridays](https://www.youtube.com/playlist?list=PL0lo9MOBetEFmtstItnKlhJJVmMghxc0P) stream weekly on GitHub's [Twitch](https://www.twitch.tv/github), [YouTube](https://www.youtube.com/github), and [LinkedIn](https://www.linkedin.com/company/github).\n",
+  link: '/schedule/2025-05-02-typewind',
+}
+
+export default typewindEvent


### PR DESCRIPTION
#245 

## Context

Currently they must have a specific time range within the one day, which is limiting for future events, and limiting for all day, multi-day conferences. At present, if anything except a specific UTC time range is entered, the event does not appear on the site.

## Changes

- Updated template for events to accept and end date
- Updated event api to handle end date and return a suitable date string
- Updated event api to handle when start and end time are not a UTC time (TBD is displayed instead)
- Updated date pill to display a date rage for multi day events

> [!IMPORTANT]  
> "All Day" has not been added, currently it will show a multi day pill at the top of the event and the start and end times as normal. This _could/should_ be updated to not display times on a multi day event

- Added tests

## Testing

A few tests have been added. It's also possible to show it on the page by updating the content of the events.

E.G.

<details><summary>Demo Screenshot</summary>
<p>

<img width="941" alt="Screenshot 2025-04-25 at 23 33 29" src="https://github.com/user-attachments/assets/5ac2698f-2dd0-40ce-9b83-303cfc00b8d1" />
<img width="480" alt="Screenshot 2025-04-25 at 23 33 09" src="https://github.com/user-attachments/assets/8aa09631-55e1-461f-b532-011a757bb8c0" />



</p>
</details> 