### PR TITLE
Inline buttons are causing white space on mobile screen

### DIFF
--- a/components/event-detail/event-detail.scss
+++ b/components/event-detail/event-detail.scss
@@ -160,6 +160,7 @@
     justify-content: space-between;
     align-items: flex-start;
     row-gap: spacing(2.5);
+    padding-bottom: spacing(2);
 
     @media (min-width: $md) {
       flex-direction: row;
@@ -173,7 +174,8 @@
     align-items: flex-start;
     justify-content: space-between;
     row-gap: spacing(2);
-    
+    flex-wrap: wrap;
+
     @media (min-width: $md) {
       flex-direction: column;
     }


### PR DESCRIPTION
#265 

## Changes

Updated css to flex wrap when required

<details><summary>Before</summary>
<p>

![Screenshot 2025-04-26 at 08 46 44](https://github.com/user-attachments/assets/723a3f29-7d20-4888-a9dc-59b065179e3c)


</p>
</details> 

<details><summary>After</summary>
<p>

![Screenshot 2025-04-26 at 08 46 58](https://github.com/user-attachments/assets/50508eb5-1292-4304-81ea-391878215dbb)


</p>
</details> 