### PR TITLE
Add Maintainer Month 2026 events: Open Source Friday + Rubber Duck Thursdays

### DIFF
--- a/content/2026/events/2026-05-01-open-source-friday-maintainer-month.md
+++ b/content/2026/events/2026-05-01-open-source-friday-maintainer-month.md
@@ -1,0 +1,16 @@
+---
+title: 'Open Source Friday - Welcome to Maintainer Month 2026'
+metaTitle: 'Open Source Friday - Welcome to Maintainer Month 2026'
+metaDesc: 'Kicking off Maintainer Month 2026 with a special Open Source Friday livestream on the GitHub YouTube channel.'
+date: '05/01'
+UTCStartTime: '15:00'
+UTCEndTime: '16:00'
+type: 'stream'
+language: 'English'
+location: 'Virtual'
+userName: 'GitHub'
+userLink: 'https://github.com/github'
+linkUrl: 'https://www.youtube.com/watch?v=Ro_VMXWbLt8'
+---
+
+Kicking off Maintainer Month 2026 with a special Open Source Friday livestream. Join us to celebrate the start of a month dedicated to open source maintainers.

--- a/content/2026/events/2026-05-01-rubber-duck-thursday-maintainer-month.md
+++ b/content/2026/events/2026-05-01-rubber-duck-thursday-maintainer-month.md
@@ -1,8 +1,8 @@
 ---
-title: 'Rubber Duck Thursday: Maintainer Month Edition — May 1'
+title: 'Rubber Duck Thursday: Maintainer Month Edition — May 7'
 metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
-date: '05/01'
+date: '05/07'
 type: 'stream'
 language: 'English'
 location: 'Virtual'

--- a/content/2026/events/2026-05-01-rubber-duck-thursday-maintainer-month.md
+++ b/content/2026/events/2026-05-01-rubber-duck-thursday-maintainer-month.md
@@ -1,0 +1,14 @@
+---
+title: 'Rubber Duck Thursday: Maintainer Month Edition — May 1'
+metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
+metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
+date: '05/01'
+type: 'stream'
+language: 'English'
+location: 'Virtual'
+userName: 'GitHub'
+userLink: 'https://github.com/github'
+linkUrl: 'https://gh.io/rubberduckthursdays'
+---
+
+Rubber Duck Thursday goes maintainer-themed for Maintainer Month. Live coding and conversation with open source maintainers on the GitHub YouTube channel.

--- a/content/2026/events/2026-05-08-rubber-duck-thursday-maintainer-month.md
+++ b/content/2026/events/2026-05-08-rubber-duck-thursday-maintainer-month.md
@@ -1,0 +1,14 @@
+---
+title: 'Rubber Duck Thursday: Maintainer Month Edition — May 8'
+metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
+metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
+date: '05/08'
+type: 'stream'
+language: 'English'
+location: 'Virtual'
+userName: 'GitHub'
+userLink: 'https://github.com/github'
+linkUrl: 'https://gh.io/rubberduckthursdays'
+---
+
+Rubber Duck Thursday goes maintainer-themed for Maintainer Month. Live coding and conversation with open source maintainers on the GitHub YouTube channel.

--- a/content/2026/events/2026-05-08-rubber-duck-thursday-maintainer-month.md
+++ b/content/2026/events/2026-05-08-rubber-duck-thursday-maintainer-month.md
@@ -1,8 +1,8 @@
 ---
-title: 'Rubber Duck Thursday: Maintainer Month Edition — May 8'
+title: 'Rubber Duck Thursday: Maintainer Month Edition — May 7'
 metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
-date: '05/08'
+date: '05/07'
 type: 'stream'
 language: 'English'
 location: 'Virtual'

--- a/content/2026/events/2026-05-15-rubber-duck-thursday-maintainer-month.md
+++ b/content/2026/events/2026-05-15-rubber-duck-thursday-maintainer-month.md
@@ -1,8 +1,8 @@
 ---
-title: 'Rubber Duck Thursday: Maintainer Month Edition — May 15'
+title: 'Rubber Duck Thursday: Maintainer Month Edition — May 14'
 metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
-date: '05/15'
+date: '05/14'
 type: 'stream'
 language: 'English'
 location: 'Virtual'

--- a/content/2026/events/2026-05-15-rubber-duck-thursday-maintainer-month.md
+++ b/content/2026/events/2026-05-15-rubber-duck-thursday-maintainer-month.md
@@ -1,0 +1,14 @@
+---
+title: 'Rubber Duck Thursday: Maintainer Month Edition — May 15'
+metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
+metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
+date: '05/15'
+type: 'stream'
+language: 'English'
+location: 'Virtual'
+userName: 'GitHub'
+userLink: 'https://github.com/github'
+linkUrl: 'https://gh.io/rubberduckthursdays'
+---
+
+Rubber Duck Thursday goes maintainer-themed for Maintainer Month. Live coding and conversation with open source maintainers on the GitHub YouTube channel.

--- a/content/2026/events/2026-05-22-rubber-duck-thursday-maintainer-month.md
+++ b/content/2026/events/2026-05-22-rubber-duck-thursday-maintainer-month.md
@@ -1,8 +1,8 @@
 ---
-title: 'Rubber Duck Thursday: Maintainer Month Edition — May 22'
+title: 'Rubber Duck Thursday: Maintainer Month Edition — May 21'
 metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
-date: '05/22'
+date: '05/21'
 type: 'stream'
 language: 'English'
 location: 'Virtual'

--- a/content/2026/events/2026-05-22-rubber-duck-thursday-maintainer-month.md
+++ b/content/2026/events/2026-05-22-rubber-duck-thursday-maintainer-month.md
@@ -1,0 +1,14 @@
+---
+title: 'Rubber Duck Thursday: Maintainer Month Edition — May 22'
+metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
+metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
+date: '05/22'
+type: 'stream'
+language: 'English'
+location: 'Virtual'
+userName: 'GitHub'
+userLink: 'https://github.com/github'
+linkUrl: 'https://gh.io/rubberduckthursdays'
+---
+
+Rubber Duck Thursday goes maintainer-themed for Maintainer Month. Live coding and conversation with open source maintainers on the GitHub YouTube channel.

--- a/content/2026/events/2026-05-29-rubber-duck-thursday-maintainer-month.md
+++ b/content/2026/events/2026-05-29-rubber-duck-thursday-maintainer-month.md
@@ -1,8 +1,8 @@
 ---
-title: 'Rubber Duck Thursday: Maintainer Month Edition — May 29'
+title: 'Rubber Duck Thursday: Maintainer Month Edition — May 28'
 metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
-date: '05/29'
+date: '05/28'
 type: 'stream'
 language: 'English'
 location: 'Virtual'

--- a/content/2026/events/2026-05-29-rubber-duck-thursday-maintainer-month.md
+++ b/content/2026/events/2026-05-29-rubber-duck-thursday-maintainer-month.md
@@ -1,0 +1,14 @@
+---
+title: 'Rubber Duck Thursday: Maintainer Month Edition — May 29'
+metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
+metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
+date: '05/29'
+type: 'stream'
+language: 'English'
+location: 'Virtual'
+userName: 'GitHub'
+userLink: 'https://github.com/github'
+linkUrl: 'https://gh.io/rubberduckthursdays'
+---
+
+Rubber Duck Thursday goes maintainer-themed for Maintainer Month. Live coding and conversation with open source maintainers on the GitHub YouTube channel.


### PR DESCRIPTION
Adds 6 events for Maintainer Month 2026 (May):

- **Open Source Friday - Welcome to Maintainer Month 2026** (May 1) — [YouTube stream](https://www.youtube.com/watch?v=Ro_VMXWbLt8)
- **Rubber Duck Thursday: Maintainer Month Edition** — weekly maintainer-themed editions (May 1, 8, 15, 22, 29) — [gh.io/rubberduckthursdays](https://gh.io/rubberduckthursdays)

Creates the `content/2026/events/` directory.

cc @abbycabs