### PR TITLE
Automate Maintainer Month event submissions

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-to-calendar.yml
+++ b/.github/ISSUE_TEMPLATE/add-to-calendar.yml
@@ -92,6 +92,13 @@ body:
     validations:
       required: true
 
+  - id: userLink
+    type: input
+    attributes:
+      label: Organizer URL
+      description: Optional web URL for the organizer
+      placeholder: 'https://'
+
   - id: linkUrl
     type: input
     attributes:

--- a/.github/workflows/event-submission-pr.yml
+++ b/.github/workflows/event-submission-pr.yml
@@ -1,0 +1,120 @@
+name: create-event-submission-pr
+
+on:
+  issues:
+    types:
+      - labeled
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  create-event-pr:
+    if: github.event.label.name == 'approved-for-calendar'
+    runs-on: ubuntu-latest
+
+    env:
+      BRANCH_NAME: event-submission-${{ github.event.issue.number }}
+      GH_TOKEN: ${{ secrets.MAINTAINER_MONTH_BOT_TOKEN || github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.MAINTAINER_MONTH_BOT_TOKEN || github.token }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Ensure workflow labels
+        run: |
+          gh label create calendar-pr-created \
+            --color 0E8A16 \
+            --description "A calendar event PR has been created for this issue" \
+            || true
+          gh label create needs-info \
+            --color D93F0B \
+            --description "More information is needed before this event can be added" \
+            || true
+
+      - name: Prepare event branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin "$BRANCH_NAME" || true
+          if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+            git switch -C "$BRANCH_NAME" "refs/remotes/origin/$BRANCH_NAME"
+          else
+            git switch -c "$BRANCH_NAME"
+          fi
+
+      - name: Generate event file
+        id: generate
+        continue-on-error: true
+        run: |
+          node scripts/event-from-issue.js \
+            --repo "$GITHUB_REPOSITORY" \
+            --issue "$ISSUE_NUMBER" \
+            --summary-file "$RUNNER_TEMP/event-pr-body.md"
+
+      - name: Mark issue as needing info
+        if: steps.generate.outcome == 'failure'
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --add-label needs-info
+          gh issue edit "$ISSUE_NUMBER" --remove-label approved-for-calendar || true
+          exit 1
+
+      - name: Validate generated event
+        run: |
+          npm test
+          npm run build
+          git restore -- public/maintainer-month-2026.ics || true
+
+      - name: Commit generated event
+        id: commit
+        run: |
+          git add content/events
+
+          if git diff --cached --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "Add Maintainer Month event from #$ISSUE_NUMBER"
+          git push --set-upstream origin "$BRANCH_NAME"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update pull request
+        run: |
+          title="Add Maintainer Month event from #$ISSUE_NUMBER"
+
+          if gh pr view "$BRANCH_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh pr edit "$BRANCH_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$title" \
+              --body-file "$RUNNER_TEMP/event-pr-body.md"
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$BRANCH_NAME" \
+              --title "$title" \
+              --body-file "$RUNNER_TEMP/event-pr-body.md"
+          fi
+
+      - name: Mark issue as PR created
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --add-label calendar-pr-created
+          gh issue edit "$ISSUE_NUMBER" --remove-label approved-for-calendar || true
+          gh issue edit "$ISSUE_NUMBER" --remove-label needs-info || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,30 @@ Need to run the website locally for testing? → [Jump to Development Guidelines
 
 ### Adding a New Event
 
+There are two supported paths for adding events.
+
+#### Submit an event with the issue form
+
+Use the "Add an event for maintainers to the calendar" issue form if you want the Maintainer Month team to create the event file for you.
+
+1. Open a new event submission issue.
+2. Fill out the event name, date, UTC time, type, language, location, organizer, public event URL, and description.
+3. A maintainer reviews the submission. If the event is approved, they apply the `approved-for-calendar` label.
+4. Automation creates a pull request with the generated event markdown file.
+5. The event appears on the site and in the ICS feed after the pull request is reviewed and merged.
+
+Maintainers use these labels for the automated flow:
+
+- `approved-for-calendar`: create or update the generated event pull request.
+- `calendar-pr-created`: the generated pull request exists.
+- `needs-info`: the issue is missing required or valid event details.
+
+The automation runs `npm test` and `npm run build` before opening the PR. If maintainers want generated PRs to also trigger the normal `pull_request` workflow, configure a `MAINTAINER_MONTH_BOT_TOKEN` repository secret with a GitHub App token or PAT. Without that secret, the workflow falls back to `GITHUB_TOKEN`.
+
+#### Submit an event with a pull request
+
+You can also open a pull request directly.
+
 1. Navigate to the `content/events/` folder
 2. Create a new markdown file with a descriptive name (e.g., `2026-05-20-your-event-name.md`)
 3. Use the following template:
@@ -66,7 +90,15 @@ Detailed description of your event goes here. You can use markdown formatting.
 ```
 
 > **Note:** `UTCStartTime` and `UTCEndTime` are optional. If omitted, the event will display "TBD" for the time. You can also set them to `'TBD'` explicitly or use `'all-day'` for events that span an entire day. Use `endDate` for multi-day events.
-5. Submit a PR with your changes
+4. Submit a PR with your changes
+
+Event PR reviewers should check that:
+
+- The event link is intended to be public.
+- The date and UTC time are correct.
+- The type, language, location, and organizer are correct.
+- The description reads well on the schedule page.
+- `npm test` and `npm run build` pass.
 
 ### Adding a New Resource
 
@@ -179,7 +211,7 @@ For significant changes like:
 - `endDate`: _(optional)_ End date in `MM/DD` format, for multi-day events (e.g., a conference running May 16-18 would use `date: '05/16'` and `endDate: '05/18'`). Multi-day events display a date range and remain listed as upcoming until the end date passes.
 - `UTCStartTime`: _(optional)_ Start time in UTC, in `HH:MM` format. Omit or set to `'TBD'` if the time is not yet confirmed. Set to `'all-day'` for events without a specific start time.
 - `UTCEndTime`: _(optional)_ End time in UTC, in `HH:MM` format. Same rules as `UTCStartTime`.
-- `type`: One of: `podcast`, `stream`, `talk`, `meetup`, `fundraising`, `conference`, `misc`
+- `type`: One of: `podcast`, `stream`, `talk`, `meetup`, `fundraising`, `conference`, `workshop`, `misc`
 - `language`: Primary language of the event
 - `location`: `Virtual` or physical location
 - `userName`: Organizer/organization name

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "cross-env NODE_ENV=production next build",
     "start": "serve out",
     "lint": "next lint",
+    "event:from-issue": "node scripts/event-from-issue.js",
     "test": "jest"
   },
   "dependencies": {

--- a/scripts/event-from-issue.js
+++ b/scripts/event-from-issue.js
@@ -1,0 +1,558 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const matter = require('gray-matter')
+
+const EVENT_YEAR = Number(process.env.MAINTAINER_MONTH_YEAR || '2026')
+const DEFAULT_OUTPUT_DIR = path.join('content', 'events')
+const NO_RESPONSE = /^_?No response_?$/i
+const VALID_EVENT_TYPES = [
+  'conference',
+  'podcast',
+  'stream',
+  'talk',
+  'meetup',
+  'fundraising',
+  'workshop',
+  'misc',
+]
+
+const FIELD_LABELS = {
+  eventName: 'Event Name',
+  date: 'Event Date',
+  endDate: 'Event End Date',
+  UTCStartTime: 'Start time in UTC',
+  UTCEndTime: 'End time in UTC',
+  type: 'Event Type',
+  language: 'Event Language',
+  location: 'Event Location',
+  userName: 'Organizer name',
+  userLink: 'Organizer URL',
+  linkUrl: 'Event URL',
+  eventDescription: 'Event Description',
+  expectedParticipants: 'Participants',
+  expectedMaintainers: 'Maintainers',
+}
+
+const REQUIRED_FIELDS = [
+  'eventName',
+  'date',
+  'type',
+  'language',
+  'location',
+  'userName',
+]
+
+function usage() {
+  return `Usage:
+  node scripts/event-from-issue.js --issue <number> [--repo owner/name] [--output-dir content/events] [--summary-file path]
+  node scripts/event-from-issue.js --issue <number> --body-file path [--output-dir content/events] [--summary-file path]
+`
+}
+
+function parseArgs(argv) {
+  const args = {}
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${arg}`)
+    }
+
+    const key = arg.slice(2)
+    const value = argv[index + 1]
+
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for --${key}`)
+    }
+
+    args[key] = value
+    index += 1
+  }
+
+  if (!args.issue) {
+    throw new Error('Missing required --issue value')
+  }
+
+  return {
+    issueNumber: String(args.issue),
+    repo: args.repo || process.env.GITHUB_REPOSITORY,
+    bodyFile: args['body-file'],
+    outputDir: args['output-dir'] || DEFAULT_OUTPUT_DIR,
+    summaryFile: args['summary-file'],
+  }
+}
+
+function fetchIssue({ repo, issueNumber }) {
+  if (!repo) {
+    throw new Error('Missing --repo or GITHUB_REPOSITORY')
+  }
+
+  const output = execFileSync(
+    'gh',
+    [
+      'issue',
+      'view',
+      issueNumber,
+      '--repo',
+      repo,
+      '--json',
+      'number,title,body,url,author',
+    ],
+    { encoding: 'utf8' },
+  )
+
+  return JSON.parse(output)
+}
+
+function readIssue({ issueNumber, repo, bodyFile }) {
+  if (bodyFile) {
+    return {
+      number: Number(issueNumber),
+      title: `Issue ${issueNumber}`,
+      body: fs.readFileSync(bodyFile, 'utf8'),
+      url: '',
+      author: null,
+    }
+  }
+
+  return fetchIssue({ repo, issueNumber })
+}
+
+function normalizeValue(value) {
+  const trimmed = (value || '').trim()
+
+  if (!trimmed || NO_RESPONSE.test(trimmed)) {
+    return ''
+  }
+
+  return trimmed
+}
+
+function parseIssueForm(body) {
+  const sections = {}
+  const normalizedBody = String(body || '').replace(/\r\n/g, '\n')
+  const headingPattern = /^###\s+(.+?)\s*$/gm
+  const recognizedLabels = Object.values(FIELD_LABELS)
+  const headings = []
+  let match
+
+  while ((match = headingPattern.exec(normalizedBody)) !== null) {
+    const label = match[1].trim()
+
+    if (recognizedLabels.includes(label)) {
+      headings.push({
+        label,
+        contentStart: headingPattern.lastIndex,
+        headingStart: match.index,
+      })
+    }
+  }
+
+  const selectedHeadings = []
+  let lastSelectedIndex = -1
+
+  recognizedLabels.forEach((label) => {
+    const headingIndex = headings.findIndex(
+      (heading, index) => index > lastSelectedIndex && heading.label === label,
+    )
+
+    if (headingIndex !== -1) {
+      selectedHeadings.push(headings[headingIndex])
+      lastSelectedIndex = headingIndex
+    }
+  })
+
+  selectedHeadings.forEach((heading, index) => {
+    const nextHeading = selectedHeadings[index + 1]
+    const contentEnd = nextHeading ? nextHeading.headingStart : normalizedBody.length
+
+    sections[heading.label] = normalizeValue(
+      normalizedBody.slice(heading.contentStart, contentEnd),
+    )
+  })
+
+  return sections
+}
+
+function getField(sections, field) {
+  return sections[FIELD_LABELS[field]] || ''
+}
+
+function parseEventDate(value, fieldName) {
+  const raw = normalizeValue(value)
+  const match = raw.match(/^(\d{1,2})\/(\d{1,2})(?:\/(\d{4}))?$/)
+
+  if (!match) {
+    throw new Error(`${fieldName} must use MM/DD or MM/DD/YYYY format`)
+  }
+
+  const month = Number(match[1])
+  const day = Number(match[2])
+  const year = match[3] ? Number(match[3]) : EVENT_YEAR
+
+  if (year !== EVENT_YEAR) {
+    throw new Error(`${fieldName} must be in ${EVENT_YEAR}`)
+  }
+
+  const date = new Date(Date.UTC(year, month - 1, day))
+  const isValid =
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+
+  if (!isValid) {
+    throw new Error(`${fieldName} is not a valid calendar date`)
+  }
+
+  return {
+    year,
+    month,
+    day,
+    frontmatter: `${pad(month)}/${pad(day)}`,
+    filenameDate: `${year}-${pad(month)}-${pad(day)}`,
+  }
+}
+
+function parseTime(value, fieldName, { allowBlank = true } = {}) {
+  const raw = normalizeValue(value)
+
+  if (!raw) {
+    if (allowBlank) return ''
+    throw new Error(`${fieldName} is required`)
+  }
+
+  const normalized = raw.toLowerCase().replace(/[\s_]/g, '-')
+
+  if (normalized === 'tbd') {
+    return 'TBD'
+  }
+
+  if (normalized === 'all-day' || normalized === 'allday') {
+    return 'all-day'
+  }
+
+  const match = raw.match(/^([01]?\d|2[0-3]):([0-5]\d)$/)
+
+  if (!match) {
+    throw new Error(`${fieldName} must use HH:MM, TBD, or all-day`)
+  }
+
+  return `${pad(Number(match[1]))}:${match[2]}`
+}
+
+function normalizeUrl(value, fieldName) {
+  const raw = normalizeValue(value)
+
+  if (!raw) {
+    return ''
+  }
+
+  const withProtocol = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw)
+    ? raw
+    : `https://${raw}`
+
+  let parsed
+
+  try {
+    parsed = new URL(withProtocol)
+  } catch (error) {
+    throw new Error(`${fieldName} must be a valid URL`)
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`${fieldName} must use http or https`)
+  }
+
+  return parsed.toString()
+}
+
+function normalizeType(value) {
+  const type = normalizeValue(value).toLowerCase()
+
+  if (!VALID_EVENT_TYPES.includes(type)) {
+    throw new Error(
+      `Event Type must be one of: ${VALID_EVENT_TYPES.join(', ')}`,
+    )
+  }
+
+  return type
+}
+
+function stripMarkdown(value) {
+  return normalizeValue(value)
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[*_#>~-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function buildMetaDescription(description, title) {
+  const text = stripMarkdown(description) || title
+
+  if (text.length <= 160) {
+    return text
+  }
+
+  return `${text.slice(0, 157).trimEnd()}...`
+}
+
+function slugify(value) {
+  const slug = normalizeValue(value)
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^A-Za-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase()
+    .slice(0, 60)
+    .replace(/-$/g, '')
+
+  if (!slug) {
+    throw new Error('Event Name must contain at least one letter or number')
+  }
+
+  return slug
+}
+
+function pad(value) {
+  return String(value).padStart(2, '0')
+}
+
+function assertRequiredFields(fields) {
+  const missing = REQUIRED_FIELDS.filter((field) => !normalizeValue(fields[field]))
+
+  if (missing.length > 0) {
+    const labels = missing.map((field) => FIELD_LABELS[field]).join(', ')
+    throw new Error(`Missing required fields: ${labels}`)
+  }
+}
+
+function assertDateRange(startDate, endDate) {
+  if (!endDate) return
+
+  const start = Date.UTC(startDate.year, startDate.month - 1, startDate.day)
+  const end = Date.UTC(endDate.year, endDate.month - 1, endDate.day)
+
+  if (end < start) {
+    throw new Error('Event End Date must be on or after Event Date')
+  }
+}
+
+function assertTimeRange(startDate, endDate, startTime, endTime) {
+  if (
+    !startTime ||
+    !endTime ||
+    startTime === 'TBD' ||
+    endTime === 'TBD' ||
+    startTime === 'all-day' ||
+    endTime === 'all-day'
+  ) {
+    return
+  }
+
+  const effectiveEndDate = endDate || startDate
+  const start = Date.UTC(
+    startDate.year,
+    startDate.month - 1,
+    startDate.day,
+    ...startTime.split(':').map(Number),
+  )
+  const end = Date.UTC(
+    effectiveEndDate.year,
+    effectiveEndDate.month - 1,
+    effectiveEndDate.day,
+    ...endTime.split(':').map(Number),
+  )
+
+  if (end <= start) {
+    throw new Error('End time must be after start time')
+  }
+}
+
+function normalizeIssueSubmission(issue) {
+  const sections = parseIssueForm(issue.body)
+  const fields = Object.fromEntries(
+    Object.keys(FIELD_LABELS).map((field) => [field, getField(sections, field)]),
+  )
+
+  assertRequiredFields(fields)
+
+  const startDate = parseEventDate(fields.date, FIELD_LABELS.date)
+  const endDate = fields.endDate
+    ? parseEventDate(fields.endDate, FIELD_LABELS.endDate)
+    : null
+  const UTCStartTime = parseTime(fields.UTCStartTime, FIELD_LABELS.UTCStartTime)
+  const UTCEndTime = parseTime(fields.UTCEndTime, FIELD_LABELS.UTCEndTime)
+
+  assertDateRange(startDate, endDate)
+  assertTimeRange(startDate, endDate, UTCStartTime, UTCEndTime)
+
+  const title = normalizeValue(fields.eventName)
+  const description = normalizeValue(fields.eventDescription)
+  const frontmatter = {
+    title,
+    metaTitle: title,
+    metaDesc: buildMetaDescription(description, title),
+    date: startDate.frontmatter,
+    type: normalizeType(fields.type),
+    language: normalizeValue(fields.language),
+    location: normalizeValue(fields.location),
+    userName: normalizeValue(fields.userName),
+  }
+
+  if (endDate) frontmatter.endDate = endDate.frontmatter
+  if (UTCStartTime) frontmatter.UTCStartTime = UTCStartTime
+  if (UTCEndTime) frontmatter.UTCEndTime = UTCEndTime
+
+  const userLink = normalizeUrl(fields.userLink, FIELD_LABELS.userLink)
+  const linkUrl = normalizeUrl(fields.linkUrl, FIELD_LABELS.linkUrl)
+
+  if (userLink) frontmatter.userLink = userLink
+  if (linkUrl) frontmatter.linkUrl = linkUrl
+
+  return {
+    issue,
+    fields,
+    frontmatter,
+    content: description,
+    slug: slugify(title),
+    filenameDate: startDate.filenameDate,
+  }
+}
+
+function renderEventMarkdown(submission) {
+  const content = submission.content
+    ? `${submission.content.trim()}\n`
+    : ''
+
+  return matter.stringify(content, submission.frontmatter)
+}
+
+function findExistingIssueFile(outputDir, issueNumber) {
+  if (!fs.existsSync(outputDir)) {
+    return null
+  }
+
+  const suffix = `-issue-${issueNumber}.md`
+  const matches = fs
+    .readdirSync(outputDir)
+    .filter((fileName) => fileName.endsWith(suffix))
+    .sort()
+
+  if (matches.length > 1) {
+    throw new Error(
+      `Found multiple existing files for issue ${issueNumber}: ${matches.join(
+        ', ',
+      )}`,
+    )
+  }
+
+  return matches[0] ? path.join(outputDir, matches[0]) : null
+}
+
+function writeEventFile(submission, outputDir) {
+  fs.mkdirSync(outputDir, { recursive: true })
+
+  const issueNumber = submission.issue.number
+  const existingPath = findExistingIssueFile(outputDir, issueNumber)
+  const fileName = `${submission.filenameDate}-${submission.slug}-issue-${issueNumber}.md`
+  const outputPath = existingPath || path.join(outputDir, fileName)
+  const markdown = renderEventMarkdown(submission)
+
+  fs.writeFileSync(outputPath, markdown, 'utf8')
+
+  return outputPath
+}
+
+function buildPullRequestBody(submission, outputPath) {
+  const fields = submission.fields
+  const issueUrl = submission.issue.url || `#${submission.issue.number}`
+  const lines = [
+    `Adds a Maintainer Month calendar event from ${issueUrl}.`,
+    '',
+    'Generated event file:',
+    `- \`${outputPath}\``,
+    '',
+    'Review checklist:',
+    '- Event title, date, and UTC time are correct.',
+    '- Event link is intended to be public.',
+    '- Event type, language, location, and organizer are correct.',
+    '- Description reads well on the schedule page.',
+    '',
+    'Submission context:',
+    `- Participants: ${normalizeValue(fields.expectedParticipants) || 'Not provided'}`,
+    `- Maintainers: ${normalizeValue(fields.expectedMaintainers) || 'Not provided'}`,
+  ]
+
+  return `${lines.join('\n')}\n`
+}
+
+function writeSummaryFile(submission, outputPath, summaryFile) {
+  if (!summaryFile) return
+
+  fs.mkdirSync(path.dirname(summaryFile), { recursive: true })
+  fs.writeFileSync(summaryFile, buildPullRequestBody(submission, outputPath), 'utf8')
+}
+
+function writeGithubOutput(outputPath, submission) {
+  const githubOutput = process.env.GITHUB_OUTPUT
+
+  if (!githubOutput) return
+
+  const lines = [
+    `event_file=${outputPath}`,
+    `event_title=${submission.frontmatter.title}`,
+  ]
+
+  fs.appendFileSync(githubOutput, `${lines.join(os.EOL)}${os.EOL}`)
+}
+
+function run(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv)
+  const issue = readIssue(options)
+  const submission = normalizeIssueSubmission(issue)
+  const outputPath = writeEventFile(submission, options.outputDir)
+
+  writeSummaryFile(submission, outputPath, options.summaryFile)
+  writeGithubOutput(outputPath, submission)
+
+  return { outputPath, submission }
+}
+
+if (require.main === module) {
+  try {
+    const result = run()
+    console.log(`Generated ${result.outputPath}`)
+  } catch (error) {
+    console.error(error.message)
+    console.error('')
+    console.error(usage())
+    process.exit(1)
+  }
+}
+
+module.exports = {
+  EVENT_YEAR,
+  FIELD_LABELS,
+  VALID_EVENT_TYPES,
+  buildMetaDescription,
+  buildPullRequestBody,
+  normalizeIssueSubmission,
+  parseArgs,
+  parseEventDate,
+  parseIssueForm,
+  parseTime,
+  renderEventMarkdown,
+  run,
+  slugify,
+  writeEventFile,
+}

--- a/tests/event-from-issue.test.js
+++ b/tests/event-from-issue.test.js
@@ -1,0 +1,246 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const matter = require('gray-matter')
+
+const {
+  buildPullRequestBody,
+  normalizeIssueSubmission,
+  parseEventDate,
+  parseTime,
+  renderEventMarkdown,
+  run,
+  slugify,
+  writeEventFile,
+} = require('../scripts/event-from-issue')
+
+const issueBody = `### Event Name
+
+Discussion: How should corporations support OSS maintainers?
+
+### Event Date
+
+05/14/2026
+
+### Event End Date
+
+05/14/2026
+
+### Start time in UTC
+
+19:00
+
+### End time in UTC
+
+20:00
+
+### Event Type
+
+meetup
+
+### Event Language
+
+English
+
+### Event Location
+
+Virtual
+
+### Organizer name
+
+Sophia Vargas - Google OSPO
+
+### Organizer URL
+
+_No response_
+
+### Event URL
+
+meet.google.com/asd-hucu-syf
+
+### Event Description
+
+This meetup will be facilitated as an open discussion focused on how corporations can best support OSS maintainers today.
+
+What programs most effectively support maintainers today and why? How can they be improved? What's missing?
+
+### Participants
+
+_No response_
+
+### Maintainers
+
+_No response_
+`
+
+const baseIssue = {
+  number: 387,
+  title: 'Discussion: How should corporations support OSS maintainers?',
+  body: issueBody,
+  url: 'https://github.com/github/maintainermonth/issues/387',
+}
+
+describe('event issue automation', () => {
+  test('normalizes a rendered add-to-calendar issue body', () => {
+    const submission = normalizeIssueSubmission(baseIssue)
+
+    expect(submission.frontmatter).toEqual({
+      title: 'Discussion: How should corporations support OSS maintainers?',
+      metaTitle: 'Discussion: How should corporations support OSS maintainers?',
+      metaDesc:
+        'This meetup will be facilitated as an open discussion focused on how corporations can best support OSS maintainers today. What programs most effectively supp...',
+      date: '05/14',
+      endDate: '05/14',
+      UTCStartTime: '19:00',
+      UTCEndTime: '20:00',
+      type: 'meetup',
+      language: 'English',
+      location: 'Virtual',
+      userName: 'Sophia Vargas - Google OSPO',
+      linkUrl: 'https://meet.google.com/asd-hucu-syf',
+    })
+    expect(submission.slug).toBe(
+      'discussion-how-should-corporations-support-oss-maintainers',
+    )
+    expect(submission.filenameDate).toBe('2026-05-14')
+  })
+
+  test('renders markdown frontmatter and body', () => {
+    const submission = normalizeIssueSubmission(baseIssue)
+    const rendered = renderEventMarkdown(submission)
+    const parsed = matter(rendered)
+
+    expect(parsed.data.title).toBe(submission.frontmatter.title)
+    expect(parsed.data.date).toBe('05/14')
+    expect(parsed.content).toContain(
+      'This meetup will be facilitated as an open discussion',
+    )
+  })
+
+  test('writes deterministic filenames with the source issue number', () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'events-'))
+    const submission = normalizeIssueSubmission(baseIssue)
+    const outputPath = writeEventFile(submission, outputDir)
+
+    expect(path.basename(outputPath)).toBe(
+      '2026-05-14-discussion-how-should-corporations-support-oss-maintainers-issue-387.md',
+    )
+    expect(fs.existsSync(outputPath)).toBe(true)
+  })
+
+  test('updates an existing file for the same issue number', () => {
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'events-'))
+    const existingPath = path.join(outputDir, '2026-05-14-old-title-issue-387.md')
+    fs.writeFileSync(existingPath, 'old content', 'utf8')
+
+    const submission = normalizeIssueSubmission(baseIssue)
+    const outputPath = writeEventFile(submission, outputDir)
+
+    expect(outputPath).toBe(existingPath)
+    expect(fs.readFileSync(existingPath, 'utf8')).toContain(
+      'Discussion: How should corporations support OSS maintainers?',
+    )
+  })
+
+  test('validates dates, times, and event types', () => {
+    expect(parseEventDate('5/4', 'Event Date')).toEqual(
+      expect.objectContaining({
+        frontmatter: '05/04',
+        filenameDate: '2026-05-04',
+      }),
+    )
+    expect(parseTime('all day', 'Start time in UTC')).toBe('all-day')
+    expect(parseTime('tbd', 'Start time in UTC')).toBe('TBD')
+
+    expect(() => parseEventDate('05/40', 'Event Date')).toThrow(
+      'valid calendar date',
+    )
+    expect(() => parseEventDate('05/14/2025', 'Event Date')).toThrow(
+      'must be in 2026',
+    )
+    expect(() =>
+      normalizeIssueSubmission({
+        ...baseIssue,
+        body: issueBody.replace('meetup', 'webinar'),
+      }),
+    ).toThrow('Event Type must be one of')
+  })
+
+  test('rejects missing required fields', () => {
+    expect(() =>
+      normalizeIssueSubmission({
+        ...baseIssue,
+        body: issueBody.replace(
+          'Sophia Vargas - Google OSPO',
+          '_No response_',
+        ),
+      }),
+    ).toThrow('Missing required fields: Organizer name')
+  })
+
+  test('does not allow description headings to override form fields', () => {
+    const submission = normalizeIssueSubmission({
+      ...baseIssue,
+      body: issueBody.replace(
+        "What's missing?",
+        "What's missing?\n\n### Event URL\n\nhttps://evil.example.com\n\n### Event Type\n\nmisc",
+      ),
+    })
+
+    expect(submission.frontmatter.linkUrl).toBe(
+      'https://meet.google.com/asd-hucu-syf',
+    )
+    expect(submission.frontmatter.type).toBe('meetup')
+    expect(submission.content).toContain('https://evil.example.com')
+  })
+
+  test('keeps slugs ascii and readable', () => {
+    expect(slugify('Café + maintainers: AI/OSS & funding!')).toBe(
+      'cafe-maintainers-ai-oss-and-funding',
+    )
+  })
+
+  test('creates a PR body with submission context', () => {
+    const submission = normalizeIssueSubmission({
+      ...baseIssue,
+      body: issueBody
+        .replace('### Participants\n\n_No response_', '### Participants\n\n50')
+        .replace('### Maintainers\n\n_No response_', '### Maintainers\n\n20'),
+    })
+    const body = buildPullRequestBody(
+      submission,
+      'content/events/test-event.md',
+    )
+
+    expect(body).toContain(
+      'Adds a Maintainer Month calendar event from https://github.com/github/maintainermonth/issues/387.',
+    )
+    expect(body).toContain('- Participants: 50')
+    expect(body).toContain('- Maintainers: 20')
+  })
+
+  test('runs from a body file for local debugging', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'event-run-'))
+    const bodyFile = path.join(tempDir, 'issue.md')
+    const outputDir = path.join(tempDir, 'events')
+    const summaryFile = path.join(tempDir, 'summary.md')
+    fs.writeFileSync(bodyFile, issueBody, 'utf8')
+
+    const result = run([
+      '--issue',
+      '387',
+      '--body-file',
+      bodyFile,
+      '--output-dir',
+      outputDir,
+      '--summary-file',
+      summaryFile,
+    ])
+
+    expect(fs.existsSync(result.outputPath)).toBe(true)
+    expect(fs.readFileSync(summaryFile, 'utf8')).toContain(
+      'Generated event file:',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add a generator for turning add-to-calendar issue form submissions into event markdown files
- add an approval-gated workflow that opens or updates generated calendar PRs
- document the issue-to-PR review flow and add tests for parser/generator behavior

## Testing
- npm test
- npm run build
- node scripts/event-from-issue.js --repo github/maintainermonth --issue 387 --output-dir <tmp>/events --summary-file <tmp>/pr-body.md