### PR TITLE
Add current event submissions

### DIFF
--- a/content/events/2026-05-14-discussion-how-should-corporations-support-oss-maintainers-issue-387.md
+++ b/content/events/2026-05-14-discussion-how-should-corporations-support-oss-maintainers-issue-387.md
@@ -1,0 +1,18 @@
+---
+title: 'Discussion: How should corporations support OSS maintainers?'
+metaTitle: 'Discussion: How should corporations support OSS maintainers?'
+metaDesc: >-
+  An open discussion on how corporations can support OSS maintainers, including
+  which programs work today, how they can improve, and what is missing.
+date: 05/14
+type: meetup
+language: English
+location: Virtual
+userName: Sophia Vargas - Google OSPO
+endDate: 05/14
+UTCStartTime: '19:00'
+UTCEndTime: '20:00'
+linkUrl: 'https://meet.google.com/asd-hucu-syf'
+---
+This meetup will be facilitated as an open discussion focused on how corporations can best support OSS maintainers today.
+What programs most effectively support maintainers today and why? How can they be improved? What’s missing?

--- a/content/events/2026-05-21-open-source-assistive-technology-hackathon-issue-385.md
+++ b/content/events/2026-05-21-open-source-assistive-technology-hackathon-issue-385.md
@@ -1,0 +1,26 @@
+---
+title: Open Source Assistive Technology Hackathon
+metaTitle: Open Source Assistive Technology Hackathon
+metaDesc: >-
+  A two-day hackathon focused on helping participants build skills and make
+  contributions to open source assistive technology projects.
+date: 05/21
+type: misc
+language: English
+location: '88 Colin P Kelly Junior Street, San Francisco, CA 94107'
+userName: Maria Lamardo
+endDate: 05/22
+UTCStartTime: '09:00'
+UTCEndTime: '07:00'
+linkUrl: >-
+  https://www.eventbrite.com/e/open-source-assistive-technology-hackathon-tickets-1984064378967
+---
+GitHub is committed to [improving the accessibility of open source software](https://github.blog/open-source/social-impact/our-pledge-to-help-improve-the-accessibility-of-open-source-software-at-scale/#reference1) and empowering people with disabilities to actively contribute. In partnership with [NV Access](https://www.nvaccess.org/), the [Center for Accessibility and Open Source](https://caos.org/), and the [Northwest Center for Assistive Technology Training](http://wssb.wa.gov/services/northwest-center-assistive-technology-training-catt-nw), we’re hosting an **Open Source Assistive Technology Hackathon** focused on empowering participants to build skills and make real contributions to the assistive technology tools people rely on every day.
+
+We will have a GitHub Learning Room where participants can learn about core GitHub contribution workflows (including NVDA and keyboard-only navigation), so they can practice navigating repositories, issues, pull requests, and code reviews with confidence.
+
+We’ll have special community spaces to help participants learn, build, and collaborate throughout the hackathon:
+- **GitHub Learning Room**: A two-day hands-on workshop where we guide learners through GitHub contribution workflows, with the capstone of contributing to an open source project and creating AI-based accessibility agents.
+- **NV Access Office Hours Room**: The NV Access team behind NVDA will be available on Day 1 to support participating projects. Stop by during office hours to ask questions, get feedback, or troubleshoot. Sign-ups will be available at the hackathon.
+
+Participants will be able to join one of 16 featured open source AT projects. We welcome people to bring their own projects and pitch them at the event.


### PR DESCRIPTION
## Summary
- Adds Open Source Assistive Technology Hackathon from #385.
- Adds Discussion: How should corporations support OSS maintainers? from #387.

## Notes
- For #385, the issue lists separate day-one and day-two end times. The calendar supports one event range, so this uses 2026-05-21 09:00 UTC through 2026-05-22 07:00 UTC and keeps the submitted schedule details in the event description.

Closes #385
Closes #387

## Validation
- npm test -- --runInBand
- npm run build