### PR TITLE
Polish schedule event cards

### DIFF
--- a/api/events.js
+++ b/api/events.js
@@ -21,6 +21,32 @@ const isAllDayValue = (value) =>
   typeof value === 'string' &&
   value.toLowerCase().replace(/[\s\-_]/g, '') === 'allday'
 
+const getUTCMonthDay = (month, day) =>
+  dayjs
+    .utc()
+    .date(1)
+    .month(month - 1)
+    .date(day)
+    .hour(0)
+    .minute(0)
+    .second(0)
+    .millisecond(0)
+
+const formatTime = (date, hour, minute) => {
+  const UTCTime = date.hour(hour).minute(minute)
+
+  if (isNaN(UTCTime)) return null
+
+  const PTTime = UTCTime.tz('America/Los_Angeles')
+
+  return {
+    utc: UTCTime.format('h:mm a'),
+    pt: PTTime.format('h:mm a'),
+    utcDate: UTCTime.format('MMM D'),
+    ptDate: PTTime.format('MMM D'),
+  }
+}
+
 export const getEvents = (year) => {
   const events_path = year ? `content/${year}/events` : 'content/events'
   if (!fs.existsSync(events_path)) return []
@@ -93,14 +119,11 @@ const formatEventDateTime = (
     throw new TypeError('date must be in mm/dd format (e.g. 06/12).')
   }
 
-  const UTCDate = dayjs
-    .utc()
-    .date(day)
-    .month(month - 1)
-
+  const UTCDate = getUTCMonthDay(month, day)
   const formattedDate = UTCDate.format('MMM D')
 
   let formattedEndDate = null
+  let endUTCDate = UTCDate
 
   if (endDate && endDate !== startDate) {
     const [endMonth, endDay] = endDate.split('/')
@@ -109,11 +132,7 @@ const formatEventDateTime = (
       throw new TypeError('date must be in mm/dd format (e.g. 06/12).')
     }
 
-    const endUTCDate = dayjs
-      .utc()
-      .date(endDay)
-      .month(endMonth - 1)
-
+    endUTCDate = getUTCMonthDay(endMonth, endDay)
     formattedEndDate = endUTCDate.format('MMM D')
   }
 
@@ -121,8 +140,18 @@ const formatEventDateTime = (
   if (isAllDayValue(startTime) || isAllDayValue(endTime)) {
     return {
       date: formattedDate,
-      startTime: { utc: ALL_DAY, pt: ALL_DAY },
-      endTime: { utc: ALL_DAY, pt: ALL_DAY },
+      startTime: {
+        utc: ALL_DAY,
+        pt: ALL_DAY,
+        utcDate: formattedDate,
+        ptDate: formattedDate,
+      },
+      endTime: {
+        utc: ALL_DAY,
+        pt: ALL_DAY,
+        utcDate: formattedEndDate || formattedDate,
+        ptDate: formattedEndDate || formattedDate,
+      },
       endDate: formattedEndDate,
       timeDisplay: 'all-day',
     }
@@ -138,16 +167,10 @@ const formatEventDateTime = (
 
   if (!isTBDValue(startTime)) {
     const [startHour, startMinute] = startTime.split(':')
+    const parsedStartTime = formatTime(UTCDate, startHour, startMinute)
 
-    const UTCStartTime = UTCDate.hour(startHour).minute(startMinute)
-
-    if (!isNaN(UTCStartTime)) {
-      const PTStartTime = UTCStartTime.tz('America/Los_Angeles')
-
-      formattedStartTime = {
-        utc: UTCStartTime.format('h:mm a'),
-        pt: PTStartTime.format('h:mm a'),
-      }
+    if (parsedStartTime) {
+      formattedStartTime = parsedStartTime
       hasSpecificStartTime = true
     }
   }
@@ -162,16 +185,10 @@ const formatEventDateTime = (
 
   if (!isTBDValue(endTime)) {
     const [endHour, endMinute] = endTime.split(':')
+    const parsedEndTime = formatTime(endUTCDate, endHour, endMinute)
 
-    const UTCEndTime = UTCDate.hour(endHour).minute(endMinute)
-
-    if (!isNaN(UTCEndTime)) {
-      const PTEndTime = UTCEndTime.tz('America/Los_Angeles')
-
-      formattedEndTime = {
-        utc: UTCEndTime.format('h:mm a'),
-        pt: PTEndTime.format('h:mm a'),
-      }
+    if (parsedEndTime) {
+      formattedEndTime = parsedEndTime
       hasSpecificEndTime = true
     }
   }

--- a/components/chip/Chip.jsx
+++ b/components/chip/Chip.jsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 
-const Chip = ({ label, icon, customColor }) => {
+const Chip = ({ label, icon, customColor, variant }) => {
   const classes = clsx('chip', {
     'custom-color': customColor,
   })
@@ -13,7 +13,11 @@ const Chip = ({ label, icon, customColor }) => {
   return (
     <div
       className={classes}
-      data-location={label.toLowerCase().includes('virtual') ? true : undefined}
+      data-location={
+        variant === 'location' || label.toLowerCase().includes('virtual')
+          ? true
+          : undefined
+      }
       data-spoken-language={isSpokenLanguage ? true : undefined}
       style={{ backgroundColor: customColor }}
     >

--- a/components/chip/chip.scss
+++ b/components/chip/chip.scss
@@ -4,6 +4,7 @@
   align-items: center;
   column-gap: 6px;
   white-space: nowrap;
+  min-width: 0;
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -46,5 +47,11 @@
     path {
       fill: $white;
     }
+  }
+
+  &__label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }

--- a/components/date-time-chip/DateTimeChip.jsx
+++ b/components/date-time-chip/DateTimeChip.jsx
@@ -1,16 +1,46 @@
 import { getLiteral } from '../../common/i18n'
 import IconClock from '../../public/icons/clock'
 
+const TimeRow = ({ children, timezone }) => (
+  <p className="datetime-chip__time">
+    <span className="datetime-chip__icon">
+      <IconClock />
+    </span>
+    <span className="datetime-chip__label">
+      {children}
+      {timezone ? (
+        <>
+          {' '}
+          <span className="datetime-chip__timezone">{timezone}</span>
+        </>
+      ) : null}
+    </span>
+  </p>
+)
+
+const formatRange = (startTime, endTime, timezone) => {
+  const start = startTime?.[timezone]
+  const end = endTime?.[timezone]
+
+  if (!start || !end) return null
+
+  const startDate = startTime?.[`${timezone}Date`]
+  const endDate = endTime?.[`${timezone}Date`]
+
+  if (startDate && endDate && startDate !== endDate) {
+    return `${startDate}, ${start} - ${endDate}, ${end}`
+  }
+
+  return `${start} - ${end}`
+}
+
 const DateTimeChip = ({ startTime, endTime, timeDisplay }) => {
   if (timeDisplay === 'all-day') {
     return (
       <div className="datetime-chip">
-        <p className="datetime-chip__time">
-          <span className="datetime-chip__icon">
-            <IconClock />
-          </span>
+        <TimeRow>
           {getLiteral('message:all-day')}
-        </p>
+        </TimeRow>
       </div>
     )
   }
@@ -18,40 +48,24 @@ const DateTimeChip = ({ startTime, endTime, timeDisplay }) => {
   if (timeDisplay === 'tbd') {
     return (
       <div className="datetime-chip">
-        <p className="datetime-chip__time">
-          <span className="datetime-chip__icon">
-            <IconClock />
-          </span>
+        <TimeRow>
           {getLiteral('message:tbd')}
-        </p>
+        </TimeRow>
       </div>
     )
   }
 
+  const utcRange = formatRange(startTime, endTime, 'utc')
+  const ptRange = formatRange(startTime, endTime, 'pt')
+
   return (
     <div className="datetime-chip">
-      {startTime ? (
-        <p className="datetime-chip__time">
-          <span className="datetime-chip__icon">
-            <IconClock />
-          </span>
-          {`${startTime.utc} - ${endTime.utc}`}
-          <span className="datetime-chip__timezone">
-            {getLiteral('timezone:utc')}
-          </span>
-        </p>
+      {utcRange ? (
+        <TimeRow timezone={getLiteral('timezone:utc')}>{utcRange}</TimeRow>
       ) : null}
 
-      {endTime ? (
-        <p className="datetime-chip__time">
-          <span className="datetime-chip__icon">
-            <IconClock />
-          </span>
-          {`${startTime.pt} - ${endTime.pt}`}
-          <span className="datetime-chip__timezone">
-            {getLiteral('timezone:pt')}
-          </span>
-        </p>
+      {ptRange ? (
+        <TimeRow timezone={getLiteral('timezone:pt')}>{ptRange}</TimeRow>
       ) : null}
     </div>
   )

--- a/components/date-time-chip/date-time-chip.scss
+++ b/components/date-time-chip/date-time-chip.scss
@@ -6,9 +6,15 @@
 
   &__time {
     display: inline-flex;
-    align-items: center;
-    white-space: nowrap;
+    align-items: flex-start;
+    min-width: 0;
+    margin: 0;
     color: $white-80;
+  }
+
+  &__label {
+    min-width: 0;
+    line-height: 1.4;
   }
 
   &__timezone {

--- a/components/event-detail/EventDetail.jsx
+++ b/components/event-detail/EventDetail.jsx
@@ -40,7 +40,7 @@ const EventDetail = ({ event, reverseColumns, isFullPage }) => {
             />
             <EventTypeChip type={event.type} />
             {event.language && <Chip label={event.language} />}
-            {event.location && <Chip label={event.location} />}
+            {event.location && <Chip label={event.location} variant="location" />}
           </div>
           <DateTimeChip
             startTime={event.formattedDate.startTime}

--- a/components/events-list/EventsList.jsx
+++ b/components/events-list/EventsList.jsx
@@ -94,11 +94,13 @@ const EventsList = ({ events }) => {
               <div className="events-list__chips">
                 <EventTypeChip type={event.type} />
                 {event.language && <Chip label={event.language} />}
-                {event.location && <Chip label={event.location} />}
+                {event.location && (
+                  <Chip label={event.location} variant="location" />
+                )}
               </div>
 
               <div className="events-list__info">
-                <p
+                <div
                   className="events-list__text"
                   dangerouslySetInnerHTML={{
                     __html: md().render(event.metaDesc || ''),

--- a/components/events-list/events-list.scss
+++ b/components/events-list/events-list.scss
@@ -67,7 +67,7 @@
 
   &__grid {
     display: grid;
-    gap: spacing(3);
+    gap: spacing(2);
     grid-template-columns: 1fr;
     
     @media (min-width: $sm) {
@@ -109,22 +109,22 @@
   }
 
   &__date {
-    padding: spacing(2) spacing(3);
+    padding: spacing(2);
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   }
 
   &__event {
-    padding: spacing(3);
+    padding: spacing(2);
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: spacing(3);
+    gap: spacing(2);
   }
 
   &__meta {
     display: flex;
     flex-direction: column;
-    gap: spacing(2);
+    gap: spacing(1.5);
   }
 
   &__chips {
@@ -141,7 +141,7 @@
 
   &__info {
     margin-top: auto;
-    padding-top: spacing(3);
+    padding-top: spacing(2);
     border-top: 1px solid rgba(255, 255, 255, 0.1);
   }
 
@@ -156,13 +156,20 @@
   }
 
   &__link {
-    @extend %header-3;
+    font-family: $inter;
+    font-weight: $semibold;
+    font-size: 1.125rem;
+    line-height: 1.35;
     color: $white;
     text-decoration: none;
     display: block;
-    margin-top: spacing(1);
+    margin-top: spacing(0.5);
     overflow-wrap: break-word;
     word-break: break-word;
+
+    @media (min-width: $md) {
+      font-size: 1.25rem;
+    }
     
     &:hover {
       text-decoration: underline;

--- a/tests/event-parsing.test.js
+++ b/tests/event-parsing.test.js
@@ -46,6 +46,21 @@ describe('Event parsing - TBD and All Day times', () => {
     expect(parsed.formattedDate.endDate).toBeTruthy()
   })
 
+  test('Event with endDate formats end time on the end date', () => {
+    const parsed = parseEvent({
+      ...baseEvent,
+      date: '05/21',
+      endDate: '05/22',
+      UTCStartTime: '09:00',
+      UTCEndTime: '07:00',
+    })
+
+    expect(parsed.formattedDate.startTime.utcDate).toBe('May 21')
+    expect(parsed.formattedDate.endTime.utcDate).toBe('May 22')
+    expect(parsed.formattedDate.startTime.ptDate).toBe('May 21')
+    expect(parsed.formattedDate.endTime.ptDate).toBe('May 22')
+  })
+
   test('Event without title throws', () => {
     expect(() => parseEvent({ ...baseEvent, title: undefined })).toThrow()
   })


### PR DESCRIPTION
## Summary
- Tightens schedule card spacing and title sizing so long event names scan better.
- Keeps long location chips inside the card.
- Shows multi-day event times with start and end dates in UTC and PT.
- Fixes schedule card description hydration by rendering Markdown into a div instead of nesting paragraphs.

## Notes
- This is the small card polish split from the broader #244 filtering/view work.
- PR #344 is still better handled in the separate #244 filtering PR, not here.

## Validation
- npm test -- --runInBand
- npm run build
- Rendered /schedule locally and checked the two current cards for overflow.