### PR TITLE
Check new event submissions

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-to-calendar.yml
+++ b/.github/ISSUE_TEMPLATE/add-to-calendar.yml
@@ -1,6 +1,8 @@
 name: 💁🏽‍♀️ Add an event for maintainers to the calendar 🎙
 description: Use this form to add an event for maintainers or highlighting maintainers to the Maintainer Month calendar.
 title: 'EVENT_NAME'
+labels:
+  - add event
 
 body:
   - type: markdown

--- a/.github/workflows/event-submission-check.yml
+++ b/.github/workflows/event-submission-check.yml
@@ -1,0 +1,77 @@
+name: check-event-submission
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-event-submission:
+    if: github.event.issue.body && contains(github.event.issue.body, '### Event Name') && contains(github.event.issue.body, '### Event Date')
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Ensure workflow labels
+        run: |
+          gh label create "add event" \
+            --color 5319E7 \
+            --description "Event submission issue" \
+            || true
+          gh label create approved-for-calendar \
+            --color 0E8A16 \
+            --description "Approved to generate a calendar event PR" \
+            || true
+          gh label create calendar-pr-created \
+            --color 0E8A16 \
+            --description "A calendar event PR has been created for this issue" \
+            || true
+          gh label create needs-info \
+            --color D93F0B \
+            --description "More information is needed before this event can be added" \
+            || true
+
+      - name: Validate event submission
+        id: validate
+        continue-on-error: true
+        run: |
+          node scripts/event-from-issue.js \
+            --repo "$GITHUB_REPOSITORY" \
+            --issue "$ISSUE_NUMBER" \
+            --output-dir "$RUNNER_TEMP/events" \
+            --summary-file "$RUNNER_TEMP/event-pr-body.md"
+
+      - name: Mark valid event submission
+        if: steps.validate.outcome == 'success'
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --add-label "add event"
+          gh issue edit "$ISSUE_NUMBER" --remove-label needs-info || true
+
+      - name: Mark issue as needing info
+        if: steps.validate.outcome == 'failure'
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --add-label "add event"
+          gh issue edit "$ISSUE_NUMBER" --add-label needs-info
+          gh issue edit "$ISSUE_NUMBER" --remove-label approved-for-calendar || true
+          exit 1

--- a/.github/workflows/event-submission-pr.yml
+++ b/.github/workflows/event-submission-pr.yml
@@ -38,6 +38,14 @@ jobs:
 
       - name: Ensure workflow labels
         run: |
+          gh label create "add event" \
+            --color 5319E7 \
+            --description "Event submission issue" \
+            || true
+          gh label create approved-for-calendar \
+            --color 0E8A16 \
+            --description "Approved to generate a calendar event PR" \
+            || true
           gh label create calendar-pr-created \
             --color 0E8A16 \
             --description "A calendar event PR has been created for this issue" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,13 +49,15 @@ Use the "Add an event for maintainers to the calendar" issue form if you want th
 
 1. Open a new event submission issue.
 2. Fill out the event name, date, UTC time, type, language, location, organizer, public event URL, and description.
-3. A maintainer reviews the submission. If the event is approved, they apply the `approved-for-calendar` label.
-4. Automation creates a pull request with the generated event markdown file.
-5. The event appears on the site and in the ICS feed after the pull request is reviewed and merged.
+3. Automation labels the issue `add event` and checks whether the required event fields are valid. If anything is missing or invalid, it applies `needs-info`.
+4. A maintainer reviews the submission. If the event is approved, they apply the `approved-for-calendar` label.
+5. Automation creates a pull request with the generated event markdown file.
+6. The event appears on the site and in the ICS feed after the pull request is reviewed and merged.
 
 Maintainers use these labels for the automated flow:
 
 - `approved-for-calendar`: create or update the generated event pull request.
+- `add event`: event submission received through the issue form.
 - `calendar-pr-created`: the generated pull request exists.
 - `needs-info`: the issue is missing required or valid event details.
 


### PR DESCRIPTION
## Summary
- label new event issue-form submissions as add event
- validate opened, edited, and reopened event submissions before approval
- apply needs-info when required event fields are missing or invalid
- keep approved-for-calendar as the manual gate for PR generation

## Validation
- ruby YAML parse for the issue template and workflows
- npm test -- --runInBand
- npm run build

Issue #392 validates successfully with the existing generator; it failed to get labels because the workflow only listened for approved-for-calendar being applied, not new issues opening.