### PR TITLE
Fix schedule card text clipping

### DIFF
--- a/components/chip/chip.scss
+++ b/components/chip/chip.scss
@@ -19,6 +19,14 @@
   &[data-location] {
     background-color: #2b5797;
     color: white;
+    white-space: normal;
+
+    .chip__label {
+      overflow: visible;
+      overflow-wrap: anywhere;
+      text-overflow: clip;
+      white-space: normal;
+    }
   }
 
   &[data-spoken-language] {

--- a/components/events-list/events-list.scss
+++ b/components/events-list/events-list.scss
@@ -192,12 +192,7 @@
     margin: 0;
     font-size: 0.875rem;
     line-height: 1.5;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow-wrap: break-word;
     
     p {
       margin: 0;


### PR DESCRIPTION
## Summary
- allow long location chips to wrap instead of truncating with ellipses
- show full schedule card descriptions instead of clamping them to three lines

## Validation
- npm test -- --runInBand
- npm run build