### PR TITLE
Fix event detail page title wrapping and chip layout

### DIFF
--- a/components/event-detail/event-detail.scss
+++ b/components/event-detail/event-detail.scss
@@ -14,8 +14,7 @@
     font-size: 1.25rem;
     line-height: 1.4;
     width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow-wrap: anywhere;
 
     &:hover {
       text-decoration: underline;
@@ -27,6 +26,8 @@
     margin-bottom: spacing(3);
     width: 100%;
     min-width: 0;
+    overflow-wrap: anywhere;
+    hyphens: auto;
 
     &[href]::after {
       content: '';
@@ -43,8 +44,8 @@
     }
 
     @media (min-width: $xl) {
-      font-size: 3rem;
-      line-height: 1.5;
+      font-size: 2.25rem;
+      line-height: 1.4;
     }
   }
 
@@ -172,12 +173,13 @@
     width: 100%;
     display: flex;
     align-items: flex-start;
-    justify-content: space-between;
     row-gap: spacing(2);
+    column-gap: spacing(2);
     flex-wrap: wrap;
 
     @media (min-width: $md) {
       flex-direction: column;
+      row-gap: spacing(1.5);
     }
   }
 

--- a/content/events/2026-05-07-rubber-duck-thursday-maintainer-month.md
+++ b/content/events/2026-05-07-rubber-duck-thursday-maintainer-month.md
@@ -1,5 +1,5 @@
 ---
-title: 'Rubber Duck Thursday: Maintainer Month Edition - May 7'
+title: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
 date: '05/07'

--- a/content/events/2026-05-14-rubber-duck-thursday-maintainer-month.md
+++ b/content/events/2026-05-14-rubber-duck-thursday-maintainer-month.md
@@ -1,5 +1,5 @@
 ---
-title: 'Rubber Duck Thursday: Maintainer Month Edition - May 14'
+title: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
 date: '05/14'

--- a/content/events/2026-05-21-rubber-duck-thursday-maintainer-month.md
+++ b/content/events/2026-05-21-rubber-duck-thursday-maintainer-month.md
@@ -1,5 +1,5 @@
 ---
-title: 'Rubber Duck Thursday: Maintainer Month Edition - May 21'
+title: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
 date: '05/21'

--- a/content/events/2026-05-28-rubber-duck-thursday-maintainer-month.md
+++ b/content/events/2026-05-28-rubber-duck-thursday-maintainer-month.md
@@ -1,5 +1,5 @@
 ---
-title: 'Rubber Duck Thursday: Maintainer Month Edition - May 28'
+title: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaTitle: 'Rubber Duck Thursday: Maintainer Month Edition'
 metaDesc: 'Live coding with maintainers as part of Maintainer Month 2026.'
 date: '05/28'


### PR DESCRIPTION
Addresses UI display issues on event detail pages (e.g. /schedule/2026-05-07-rubber-duck-thursday-maintainer-month) where long titles rendered awkwardly in JetBrains Mono at 3rem and chips spread vertically with large gaps.

## Changes

- `event-detail.scss`: title gets `overflow-wrap: anywhere` and `hyphens: auto` so long titles break cleanly. xl breakpoint title size reduced from 3rem to 2.25rem.
- `event-detail.scss`: `event-detail__user` no longer hides overflow without `white-space: nowrap` (the ellipsis never triggered, but `overflow: hidden` could clip).
- `event-detail.scss`: `event-detail__column` uses explicit row/column gap instead of `justify-content: space-between` so chips stack tightly.
- Shortened the four Rubber Duck Thursday event titles by removing the trailing "- May N" since the date is already shown in the date chip.

## Validation

- `npm test` passes (39 tests)
- `npm run build` succeeds