### PR TITLE
Remove '2026 Theme: Coming Soon' section from home

### DIFF
--- a/components/home/about/About.jsx
+++ b/components/home/about/About.jsx
@@ -8,7 +8,7 @@ import useParallax from '../../../hooks/useParallax'
 import ExampleCard from '../get-involved/ExampleCard'
 
 
-const About = ({ title, content, theme1, theme2 }) => {
+const About = ({ title, content }) => {
   const image1 = useRef(null)
   const image2 = useRef(null)
 
@@ -42,12 +42,6 @@ const About = ({ title, content, theme1, theme2 }) => {
         <div
           dangerouslySetInnerHTML={{ __html: md().render(content) }}
         />
-        <div className="about__themes">
-          <div>
-            <h3 className="get-involved__example-subtitle">2026 Theme: Coming Soon</h3>
-            <p className="get-involved__text">{theme1}</p>
-          </div>
-        </div>
       </div>
       </div>
     </section>

--- a/content/home/2-about.md
+++ b/content/home/2-about.md
@@ -1,8 +1,6 @@
 ---
 anchorNavSection: 'About'
 title: 'Welcome to Maintainer Month!'
-theme1: "Stay tuned for this year's theme. In the meantime, get involved by hosting an event or sharing your maintainer story."
-theme2: 'Maintainers keep the software ecosystem running, but they’re humans, not machines. Do you know who the maintainers you rely on are? Do you know what kind of support those individuals actually need? Ask what you can do for them, and be ready to listen.'
 ---
 
 Open source runs the world, but who runs open source? Open source maintainers are behind the software we use everyday, but they don't always have the community or support they need. That's why we're celebrating open source maintainers during the month of May.

--- a/pages/index.js
+++ b/pages/index.js
@@ -64,7 +64,7 @@ export default function Home({ hero, about, news, getInvolved, events, connectio
             buttonText={hero.buttonText}
             buttonLink={ROUTES.SCHEDULE.path}
           />
-          <About title={about.title} content={about.content} theme1={about.theme1} theme2={about.theme2}/>
+          <About title={about.title} content={about.content}/>
           <GetInvolved
             title={getInvolved.title}
             content={getInvolved.content}


### PR DESCRIPTION
Removes the placeholder theme block from the home page About section.

Changes:
- `components/home/about/About.jsx` — drops the `about__themes` div and unused theme props.
- `content/home/2-about.md` — removes `theme1` and `theme2` frontmatter.
- `pages/index.js` — stops passing `theme1`/`theme2` to `<About />`.

Validated with `npm test` (39 pass) and `npm run build`.