### PR TITLE
Shorten event location to City, State

### DIFF
--- a/content/events/2026-05-21-open-source-assistive-technology-hackathon-issue-385.md
+++ b/content/events/2026-05-21-open-source-assistive-technology-hackathon-issue-385.md
@@ -7,7 +7,7 @@ metaDesc: >-
 date: 05/21
 type: misc
 language: English
-location: '88 Colin P Kelly Junior Street, San Francisco, CA 94107'
+location: 'San Francisco, CA'
 userName: Maria Lamardo
 endDate: 05/22
 UTCStartTime: '09:00'


### PR DESCRIPTION
Updates the Open Source Assistive Technology Hackathon location from the full GitHub HQ street address to `San Francisco, CA`.

Schedule cards render `location` as a chip — `City, State` (or `City, Country`) reads better than a full street address and matches the [issue template guidance](https://github.com/github/maintainermonth/blob/main/.github/ISSUE_TEMPLATE/add-to-calendar.yml) which says "Primary location of the event - either Virtual or a City + Country".