### PR TITLE
Fix mobile/tablet overflow on home events and header pill

### DIFF
--- a/components/header/header.scss
+++ b/components/header/header.scss
@@ -62,6 +62,7 @@
     background: $white;
     box-sizing: border-box;
     border-radius: 27px;
+    white-space: nowrap;
 
     @extend %subtitle-1;
     color: $purple;

--- a/components/home/events/events.scss
+++ b/components/home/events/events.scss
@@ -17,6 +17,7 @@
 
   &__list {
     margin-left: spacing(5);
+    margin-right: spacing(5);
 
     display: flex;
     flex-direction: column;
@@ -24,6 +25,7 @@
 
     @media (min-width: $lg) {
       margin-left: 0;
+      margin-right: 0;
     }
 
     @media (min-width: $lg) {


### PR DESCRIPTION
Two small mobile fixes found during a Playwright responsiveness audit at 375x667 (mobile) and 768x1024 (tablet).

## What changed

### 1. Home page event cards no longer clip past the right edge

`.events__list` had `margin-left: spacing(5)` on mobile/tablet with no matching right margin. Because `.event-detail` is `width: 100%`, the cards extended ~32px past the parent on mobile and ~40px on tablet. `body` has `overflow-x: hidden` so users couldn't scroll to see the clipped content — they just saw truncated cards.

Added matching `margin-right: spacing(5)` (resets to 0 at `$lg`).

### 2. Header "May 2026" pill stays on one line at narrow widths

The pill in the sticky header wrapped to two lines below ~390px viewport width. Added `white-space: nowrap` so it stays single-line.

## Verification

- `npm test` (39/39 pass)
- `npm run build` clean
- Playwright at 375x667: home cards, schedule, library, partner-pack, ships, event detail page — no non-decorative overflow remaining (only `.layout__front-bubble` decorative element, which is intentional)
- Playwright at 768x1024: home cards no longer overflow at tablet width either

Pages verified clean in the audit (no other layout bugs found): `/schedule`, `/library`, `/partner-pack`, `/ships`, event detail slug pages.