### PR TITLE
Fix heading hierarchy on home and library pages

### DIFF
--- a/components/home/get-involved/GetInvolved.jsx
+++ b/components/home/get-involved/GetInvolved.jsx
@@ -18,7 +18,7 @@ const GetInvolved = ({ title, examplesTitle, examples, content, maintainersTitle
 
         <div className="get-involved__header">
           <div className="get-involved__title">
-          <h2 >{maintainersTitle}</h2>
+          <h3>{maintainersTitle}</h3>
 
           <img
             className="get-involved__image"
@@ -36,7 +36,7 @@ const GetInvolved = ({ title, examplesTitle, examples, content, maintainersTitle
 
         <div className="get-involved__header">
           <div className="get-involved__title">
-          <h2 >{partnersTitle}</h2>
+          <h3>{partnersTitle}</h3>
 
           <img
             className="get-involved__image"

--- a/components/library-links/LibraryLinks.jsx
+++ b/components/library-links/LibraryLinks.jsx
@@ -17,14 +17,16 @@ const LibraryLinks = ({ links }) => {
         <article key={link.title} className="library-links__item">
           <div className="library-links__info">
             <p className="library-links__author">{link.author}</p>
-            <a
-              className="library-links__link"
-              href={link.link}
-              target="_blank"
-              rel="noreferrer"
-            >
-              {link.title}
-            </a>
+            <h2 className="library-links__title">
+              <a
+                className="library-links__link"
+                href={link.link}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {link.title}
+              </a>
+            </h2>
           </div>
           <p className="library-links__description">{link.description}</p>
           <div className="library-links__chips">

--- a/components/library-links/library-links.scss
+++ b/components/library-links/library-links.scss
@@ -7,12 +7,25 @@
         padding-right: spacing(3);
     }
 
+    &__heading {
+        padding: 0 spacing(3);
+        margin-bottom: spacing(2);
+
+        @extend %header-1;
+    }
+
     &__intro {
         position: relative;
         padding: spacing(3);
     }
     &__intro a {
         text-decoration:underline;
+    }
+
+    &__title {
+        margin: 0;
+        font: inherit;
+        color: inherit;
     }
 
     &__item {

--- a/components/section-divider/SectionDivider.jsx
+++ b/components/section-divider/SectionDivider.jsx
@@ -4,7 +4,7 @@ const SectionDivider = ({ title }) => {
   return (
     <div className="section-divider">
       <div className="section-divider__content">
-        <h3 className="section-divider__title">{title}</h3>
+        <h2 className="section-divider__title">{title}</h2>
         <IconArrowRight />
       </div>
     </div>

--- a/pages/library.js
+++ b/pages/library.js
@@ -47,6 +47,7 @@ export default function Library() {
       </Head>
 
       <div className="library-links">
+        <h1 className="library-links__heading">{getLiteral('library:title')}</h1>
         <div className="library-links__intro">
         Stories and interviews featuring maintainers of your favourite open source projects! Have a maintainer story to share? <a href="https://github.com/github/maintainermonth/issues/new?assignees=&labels=&template=add-to-library.yaml&title=TITLE">Add it here!</a>
         </div>


### PR DESCRIPTION
Closes the heading-semantics gap surfaced in the UX review.

**Home page**
- `SectionDivider` now renders `h2` (was `h3`) so top-level sections like "How do I get involved?", "Upcoming events 2026", and "We have a full month of activities" are at the right level under the hero `h1`.

**Library page**
- Page now has an `h1` "Library" above the intro paragraph (was a bare `div`).
- Each entry's link title is wrapped in an `h2` so screen readers and SEO see a real heading per card. Visual styling is unchanged (the existing `library-links__link` class still extends `%header-2`).