### PR TITLE
Add category filter to Ships page

### DIFF
--- a/components/ships/Ships.jsx
+++ b/components/ships/Ships.jsx
@@ -1,5 +1,8 @@
+import { useMemo, useState } from 'react'
+
 import Chip from '../chip/Chip'
 import { getLiteral } from '../../common/i18n'
+import ShipsFilter from './ShipsFilter'
 
 const formatDate = (dateString) => {
   const date = new Date(dateString + 'T00:00:00')
@@ -11,6 +14,29 @@ const formatDate = (dateString) => {
 }
 
 const Ships = ({ ships }) => {
+  const [selected, setSelected] = useState('all')
+
+  const sorted = useMemo(
+    () =>
+      ships
+        ? [...ships].sort((a, b) => new Date(b.date) - new Date(a.date))
+        : [],
+    [ships]
+  )
+
+  const categories = useMemo(() => {
+    const counts = sorted.reduce((acc, ship) => {
+      const value = ship.category
+      if (!value) return acc
+      acc[value] = (acc[value] || 0) + 1
+      return acc
+    }, {})
+
+    return Object.keys(counts)
+      .sort((a, b) => a.localeCompare(b))
+      .map((value) => ({ value, count: counts[value] }))
+  }, [sorted])
+
   if (!ships || ships.length === 0) {
     return (
       <section className="ships">
@@ -21,19 +47,29 @@ const Ships = ({ ships }) => {
     )
   }
 
-  const sorted = [...ships].sort(
-    (a, b) => new Date(b.date) - new Date(a.date)
-  )
+  const filtered =
+    selected === 'all' ? sorted : sorted.filter((s) => s.category === selected)
 
   return (
     <section className="ships">
       <div className="ships__intro">
         <h2 className="ships__heading">{getLiteral('ships:title')}</h2>
         <p className="ships__subtitle">{getLiteral('ships:description')}</p>
+        <ShipsFilter
+          categories={categories}
+          selected={selected}
+          onSelect={setSelected}
+          totalShips={sorted.length}
+        />
       </div>
-      <div className="ships__grid">
-        {sorted.map((ship) => (
-          <article key={ship.url} className="ships__card">
+      {filtered.length === 0 ? (
+        <p className="ships__empty">
+          {getLiteral('ships:empty-no-matches')}
+        </p>
+      ) : (
+        <div className="ships__grid">
+          {filtered.map((ship) => (
+          <article key={`${ship.url}-${ship.title}`} className="ships__card">
             <a
               className="ships__link"
               href={ship.url}
@@ -61,8 +97,9 @@ const Ships = ({ ships }) => {
               </div>
             </a>
           </article>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
     </section>
   )
 }

--- a/components/ships/ShipsFilter.jsx
+++ b/components/ships/ShipsFilter.jsx
@@ -1,0 +1,40 @@
+import { getLiteral } from '../../common/i18n'
+
+const ShipsFilter = ({ categories, selected, onSelect, totalShips }) => {
+  if (categories.length === 0) return null
+
+  return (
+    <div className="ships-filter" aria-label={getLiteral('ships:filter-label')}>
+      <span className="ships-filter__label">
+        {getLiteral('ships:filter-label')}
+      </span>
+      <div className="ships-filter__options">
+        <button
+          type="button"
+          className="ships-filter__option"
+          data-active={selected === 'all' ? true : undefined}
+          aria-pressed={selected === 'all'}
+          onClick={() => onSelect('all')}
+        >
+          {getLiteral('ships:filter-all')}
+          <span className="ships-filter__count">{totalShips}</span>
+        </button>
+        {categories.map((category) => (
+          <button
+            key={category.value}
+            type="button"
+            className="ships-filter__option"
+            data-active={selected === category.value ? true : undefined}
+            aria-pressed={selected === category.value}
+            onClick={() => onSelect(category.value)}
+          >
+            {category.value}
+            <span className="ships-filter__count">{category.count}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default ShipsFilter

--- a/components/ships/ships-filter.scss
+++ b/components/ships/ships-filter.scss
@@ -1,0 +1,61 @@
+.ships-filter {
+  display: flex;
+  flex-direction: column;
+  gap: spacing(1);
+  margin-top: spacing(3);
+
+  &__label {
+    @extend %subtitle-2;
+    color: $white-80;
+  }
+
+  &__options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: spacing(1);
+  }
+
+  &__option {
+    display: inline-flex;
+    align-items: center;
+    gap: spacing(1);
+    padding: spacing(1) spacing(1.5);
+    border: 1px solid $white-40;
+    border-radius: 27px;
+    background: transparent;
+    color: $white-80;
+    @extend %subtitle-2;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+
+    &:hover,
+    &:focus-visible,
+    &[data-active] {
+      background: $white;
+      border-color: $white;
+      color: $purple;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $green;
+      outline-offset: 2px;
+    }
+  }
+
+  &__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.5em;
+    padding: 0 spacing(0.5);
+    border-radius: 999px;
+    background: $white-20;
+    font-size: 0.75rem;
+  }
+
+  &__option[data-active] &__count,
+  &__option:hover &__count,
+  &__option:focus-visible &__count {
+    background: rgba($purple, 0.12);
+  }
+}

--- a/content/commons.json
+++ b/content/commons.json
@@ -76,6 +76,9 @@
     "ships:title": "Ships for Maintainers",
     "ships:description": "GitHub features and updates built for open source maintainers.",
     "ships:empty": "No ships listed yet. Check back soon!",
+    "ships:empty-no-matches": "No ships in this category yet.",
+    "ships:filter-label": "Filter by category",
+    "ships:filter-all": "All",
 
     "schedule:title": "Schedule",
     "schedule:description": "List of all events organized during this year's Maintainer Month",

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -31,6 +31,7 @@
 @import '../components/academia/academia';
 
 @import '../components/ships/ships';
+@import '../components/ships/ships-filter';
 
 @import '../components/not-found/not-found';
 


### PR DESCRIPTION
Addresses item #6 from the UX review: the Ships page had no way to filter the long list of changelog entries.

## Changes
- New `ShipsFilter` component renders pill-style chips above the grid (one per category, plus "All"). Each chip shows the category name and a count badge.
- Clicking a chip filters the grid in place; "All" resets.
- Styling mirrors the existing `EventFilter` pattern (white-on-purple chips, active state with white background and purple text, focus ring).
- Adds three `ships:*` i18n keys to `content/commons.json`.
- Stabilizes the card key from `ship.url` to `\`${ship.url}-${ship.title}\``. The data has 3 ships sharing the placeholder URL `https://github.blog/changelog/`, which was causing React to reuse stale DOM nodes across filter changes (PRs filter showing OrgMgmt cards, etc.). This is the minimum fix; cleaning up the duplicate URLs in `ships.json` is a separate content task.

## Verified locally
- `npm test` 39/39 pass
- `npm run build` clean
- Playwright at `/ships`: each category chip filters to exactly its count (Pull Requests 8, Copilot 2, Actions 1, Org Management 2, etc.), "All" returns 40.

Screenshot of the filter UI:

```
All 40 | Actions 1 | Application Security 2 | Code View 3 | Copilot 2 |
Issues 6 | Moderation 3 | Notifications 4 | Organization Management 2 |
Pull Requests 8 | Repository Management 3 | Supply Chain Security 6
```