### PR TITLE
Allow calendar events without URLs

### DIFF
--- a/api/calendar.js
+++ b/api/calendar.js
@@ -24,8 +24,11 @@ function toICSEvent(event) {
     title: event.title,
     description: event.metaDesc || '',
     location: event.location || '',
-    url: event.linkUrl || '',
     calName: 'Maintainer Month 2026',
+  }
+
+  if (event.linkUrl) {
+    icsEvent.url = event.linkUrl
   }
 
   if (hasTime) {

--- a/tests/calendar.test.js
+++ b/tests/calendar.test.js
@@ -1,0 +1,41 @@
+jest.mock('ics', () => ({
+  createEvents: jest.fn(() => ({ value: 'BEGIN:VCALENDAR\nEND:VCALENDAR' })),
+}))
+
+const { createEvents } = require('ics')
+const { generateICS } = require('../api/calendar')
+
+const baseEvent = {
+  title: 'Maintainer event',
+  metaDesc: 'A Maintainer Month event.',
+  date: '05/28',
+  UTCStartTime: '15:00',
+  UTCEndTime: '15:30',
+  location: 'Virtual',
+}
+
+describe('calendar ICS generation', () => {
+  beforeEach(() => {
+    createEvents.mockClear()
+  })
+
+  test('omits URL when an event does not have a link URL', () => {
+    generateICS([baseEvent])
+
+    const icsEvent = createEvents.mock.calls[0][0][0]
+    expect(icsEvent.title).toBe('Maintainer event')
+    expect(icsEvent).not.toHaveProperty('url')
+  })
+
+  test('includes URL when an event has a link URL', () => {
+    generateICS([
+      {
+        ...baseEvent,
+        linkUrl: 'https://github.com/github/maintainermonth',
+      },
+    ])
+
+    const icsEvent = createEvents.mock.calls[0][0][0]
+    expect(icsEvent.url).toBe('https://github.com/github/maintainermonth')
+  })
+})


### PR DESCRIPTION
Fixes the event-submission workflow failure when an approved calendar issue does not include an Event URL.

The generated event can omit `linkUrl`, but ICS generation was still passing `url: ""` to the `ics` package. The package rejects empty URLs during the production build. This change only adds the ICS `url` field when an event has a link URL.

Validation:
- npm test -- --runInBand
- Generated event from #404 locally and ran npm run build