### PR TITLE
Add events: Maintainers Meetup Delhi (#409) and AssertJ talk (#392)

### DIFF
--- a/content/events/2026-05-09-maintainers-meetup-delhi-issue-409.md
+++ b/content/events/2026-05-09-maintainers-meetup-delhi-issue-409.md
@@ -1,0 +1,19 @@
+---
+title: Maintainers Meetup Delhi
+metaTitle: Maintainers Meetup Delhi
+metaDesc: >-
+  As part of MaintainersMay, FOSS United Foundation is organising Maintainer
+  Meetups all over India. An unconference-style event for FOSS maintainers.
+date: 05/09
+type: meetup
+language: English
+location: 'Delhi, India'
+userName: FOSS United Foundation
+endDate: 05/09
+UTCStartTime: '10:30'
+UTCEndTime: '13:30'
+linkUrl: 'https://fossunited.org/c/delhi/maintainers-meetup'
+---
+As part of #MaintainersMay, FOSS United Foundation is organising Maintainer Meetups all over India!
+
+Maintainers Meetup Delhi is a dedicated event for FOSS and digital commons maintainers to get together and discuss their perspectives and day-to-day challenges of a maintainer. This is an unconference-style event, which means the schedule of sessions is decided upon by the attendees at the venue.

--- a/content/events/2026-05-12-whats-wrong-with-assertj-issue-392.md
+++ b/content/events/2026-05-12-whats-wrong-with-assertj-issue-392.md
@@ -1,0 +1,22 @@
+---
+title: "What's wrong with AssertJ?!"
+metaTitle: "What's wrong with AssertJ?!"
+metaDesc: >-
+  AssertJ maintainer Stefano Cordio explores the technical debt and API
+  inconsistencies accumulated over the 3.x era and how AssertJ 4 is being built
+  to meet the testing challenges of the next decade.
+date: 05/12
+type: talk
+language: English
+location: 'Zurich, Switzerland'
+userName: Stefano Cordio
+endDate: 05/12
+UTCStartTime: '18:15'
+UTCEndTime: '19:30'
+linkUrl: 'https://www.jug.ch/html/events/2026/assertj.html'
+---
+AssertJ has been a player in Java testing for over a decade, providing an intuitive set of strongly typed assertions designed to maximize test readability. The transition to version 4 represents a great opportunity to address long-standing API inconsistencies and structural compromises.
+
+In this talk, we will candidly explore the technical debt and API inconsistencies accumulated over the 3.x era. We will see how AssertJ 4 is being built to eliminate friction for developers and meet the testing challenges of the next decade.
+
+After the talk, you will have the opportunity to exchange ideas and network with the speaker and professional colleagues over beer and rich finger foods.


### PR DESCRIPTION
Adds two community-submitted events to the Maintainer Month calendar:

- **Maintainers Meetup Delhi** (May 9) - FOSS United Foundation unconference for maintainers. Closes #409.
- **What's wrong with AssertJ?!** (May 12) - Java User Group CH talk by Stefano Cordio on AssertJ 4. Closes #392.