### PR TITLE
Enable partner pack offers on page

### DIFF
--- a/pages/partner-pack.js
+++ b/pages/partner-pack.js
@@ -47,8 +47,7 @@ export default function PartnerPack({ content, frontmatter, partnerOffers, addit
         </div>
         <div className="partner-pack__content">
           <div dangerouslySetInnerHTML={{ __html: content }}></div>
-          {/* Offers component commented out until Maintainer Month 2026
-          <Offers partnerOffers={partnerOffers} additionalSections={additionalSections} /> */}
+          <Offers partnerOffers={partnerOffers} additionalSections={additionalSections} />
           <div className="partner-pack__message">
             <h2>Become a Maintainer Month 2026 Partner</h2>
             <p>We&apos;re looking for partners to offer exclusive perks, tools, and resources to open source maintainers during Maintainer Month 2026. If your company wants to support the maintainers behind the software we all depend on, we&apos;d love to hear from you.</p>


### PR DESCRIPTION
Uncomments the Offers component on the partner pack page so partner cards actually render. Tab is still hidden from nav.