### PR TITLE
Add May 2026 Open Source Friday events

### DIFF
--- a/content/events/2026-05-01-remotion.md
+++ b/content/events/2026-05-01-remotion.md
@@ -1,0 +1,18 @@
+---
+title: 'Open Source Friday: Remotion'
+metaTitle: 'Open Source Friday: Remotion'
+metaDesc: 'Johnny Burger on Remotion, an open source framework for creating videos programmatically using React.'
+date: '05/01'
+UTCStartTime: '18:00'
+UTCEndTime: '19:00'
+type: 'stream'
+language: 'English'
+location: 'Virtual'
+userName: 'GitHub'
+userLink: 'https://github.com/github'
+linkUrl: 'https://www.youtube.com/@GitHub'
+---
+
+Join [Johnny Burger](https://github.com/JonnyBurger) for a look at [Remotion](https://github.com/remotion-dev/remotion), an open source framework for creating videos programmatically using React.
+
+[Open Source Fridays](https://www.youtube.com/playlist?list=PL0lo9MOBetEFmtstItnKlhJJVmMghxc0P) stream weekly on GitHub's [YouTube](https://www.youtube.com/@GitHub), [Twitch](https://www.twitch.tv/github), and [LinkedIn](https://www.linkedin.com/company/github).

--- a/content/events/2026-05-08-spec-kit.md
+++ b/content/events/2026-05-08-spec-kit.md
@@ -1,7 +1,7 @@
 ---
 title: 'Open Source Friday: Spec Kit'
 metaTitle: 'Open Source Friday: Spec Kit'
-metaDesc: 'Den Delimarsky (@localden) on Spec Kit, an open source toolkit for building software with AI via specifications.'
+metaDesc: 'Manfred Riem (@mnriem) on Spec Kit, an open source toolkit for building software with AI via specifications.'
 date: '05/08'
 UTCStartTime: '17:00'
 UTCEndTime: '18:00'
@@ -13,6 +13,6 @@ userLink: 'https://github.com/github'
 linkUrl: 'https://www.youtube.com/@GitHub'
 ---
 
-Join [Den Delimarsky](https://github.com/localden) for a look at [Spec Kit](https://github.com/microsoft/spec-kit), an open source toolkit for building software with AI via specifications.
+Join [Manfred Riem](https://github.com/@mnriem) for a look at [Spec Kit](https://github.com/microsoft/spec-kit), an open source toolkit for building software with AI via specifications.
 
 [Open Source Fridays](https://www.youtube.com/playlist?list=PL0lo9MOBetEFmtstItnKlhJJVmMghxc0P) stream weekly on GitHub's [YouTube](https://www.youtube.com/@GitHub), [Twitch](https://www.twitch.tv/github), and [LinkedIn](https://www.linkedin.com/company/github).

--- a/content/events/2026-05-08-spec-kit.md
+++ b/content/events/2026-05-08-spec-kit.md
@@ -1,0 +1,18 @@
+---
+title: 'Open Source Friday: Spec Kit'
+metaTitle: 'Open Source Friday: Spec Kit'
+metaDesc: 'Den Delimarsky (@localden) on Spec Kit, an open source toolkit for building software with AI via specifications.'
+date: '05/08'
+UTCStartTime: '17:00'
+UTCEndTime: '18:00'
+type: 'stream'
+language: 'English'
+location: 'Virtual'
+userName: 'GitHub'
+userLink: 'https://github.com/github'
+linkUrl: 'https://www.youtube.com/@GitHub'
+---
+
+Join [Den Delimarsky](https://github.com/localden) for a look at [Spec Kit](https://github.com/microsoft/spec-kit), an open source toolkit for building software with AI via specifications.
+
+[Open Source Fridays](https://www.youtube.com/playlist?list=PL0lo9MOBetEFmtstItnKlhJJVmMghxc0P) stream weekly on GitHub's [YouTube](https://www.youtube.com/@GitHub), [Twitch](https://www.twitch.tv/github), and [LinkedIn](https://www.linkedin.com/company/github).

--- a/content/events/2026-05-22-age-assurance-laws-and-open-source.md
+++ b/content/events/2026-05-22-age-assurance-laws-and-open-source.md
@@ -1,7 +1,7 @@
 ---
 title: 'Maintainer Month Panel: Age Assurance Laws and Open Source'
 metaTitle: 'Maintainer Month Panel: Age Assurance Laws and Open Source'
-metaDesc: 'Maintainer Month panel with FreeBSD Foundation, OSI, and GitHub on age-assurance policy impact on open source software.'
+metaDesc: 'Anne Dickison (FreeBSD Foundation), Katie Steen-James (OSI), and Margaret Tucker (GitHub) on age-assurance laws and open source.'
 date: '05/22'
 UTCStartTime: '16:00'
 UTCEndTime: '17:00'
@@ -13,4 +13,4 @@ userLink: 'https://github.com/margaret-tucker'
 linkUrl: 'https://www.youtube.com/watch?v=1yXuKjwIYEM'
 ---
 
-A Maintainer Month panel featuring voices from the FreeBSD Foundation, the Open Source Initiative (OSI), and GitHub exploring how age-assurance legislation could impact open source software development and distribution.
+Age assurance laws are reaching down to operating systems and app stores. Anne Dickison (FreeBSD Foundation), Katie Steen-James (OSI), and Margaret Tucker (GitHub) break down what's happening across the US, Brazil, and Europe, and how maintainers can help shape policy that fits how open source actually works.

--- a/content/events/2026-05-22-age-assurance-laws-and-open-source.md
+++ b/content/events/2026-05-22-age-assurance-laws-and-open-source.md
@@ -1,0 +1,16 @@
+---
+title: 'Maintainer Month Panel: Age Assurance Laws and Open Source'
+metaTitle: 'Maintainer Month Panel: Age Assurance Laws and Open Source'
+metaDesc: 'Maintainer Month panel with FreeBSD Foundation, OSI, and GitHub on age-assurance policy impact on open source software.'
+date: '05/22'
+UTCStartTime: '16:00'
+UTCEndTime: '17:00'
+type: 'stream'
+language: 'English'
+location: 'Virtual'
+userName: 'GitHub'
+userLink: 'https://github.com/github'
+linkUrl: 'https://www.youtube.com/@GitHub'
+---
+
+A Maintainer Month panel featuring voices from the FreeBSD Foundation, the Open Source Initiative (OSI), and GitHub exploring how age-assurance legislation could impact open source software development and distribution.

--- a/content/events/2026-05-22-age-assurance-laws-and-open-source.md
+++ b/content/events/2026-05-22-age-assurance-laws-and-open-source.md
@@ -9,8 +9,8 @@ type: 'stream'
 language: 'English'
 location: 'Virtual'
 userName: 'GitHub'
-userLink: 'https://github.com/github'
-linkUrl: 'https://www.youtube.com/@GitHub'
+userLink: 'https://github.com/margaret-tucker'
+linkUrl: 'https://www.youtube.com/watch?v=1yXuKjwIYEM'
 ---
 
 A Maintainer Month panel featuring voices from the FreeBSD Foundation, the Open Source Initiative (OSI), and GitHub exploring how age-assurance legislation could impact open source software development and distribution.

--- a/content/events/2026-05-22-openmind-om1.md
+++ b/content/events/2026-05-22-openmind-om1.md
@@ -8,8 +8,8 @@ UTCEndTime: '18:00'
 type: 'stream'
 language: 'English'
 location: 'Virtual'
-userName: 'GitHub'
-userLink: 'https://github.com/github'
+userName: 'prachi1615'
+userLink: 'https://github.com/prachi1615'
 linkUrl: 'https://www.youtube.com/@GitHub'
 ---
 

--- a/content/events/2026-05-22-openmind-om1.md
+++ b/content/events/2026-05-22-openmind-om1.md
@@ -1,0 +1,18 @@
+---
+title: 'Open Source Friday: OpenMind (OM1)'
+metaTitle: 'Open Source Friday: OpenMind (OM1)'
+metaDesc: 'Prachi Sethi on OM1, an open source, hardware-agnostic cognition stack for robots.'
+date: '05/22'
+UTCStartTime: '17:00'
+UTCEndTime: '18:00'
+type: 'stream'
+language: 'English'
+location: 'Virtual'
+userName: 'GitHub'
+userLink: 'https://github.com/github'
+linkUrl: 'https://www.youtube.com/@GitHub'
+---
+
+Join Prachi Sethi for a look at [OM1](https://github.com/OpenmindAGI/OM1), an open source, hardware-agnostic cognition stack for robots.
+
+[Open Source Fridays](https://www.youtube.com/playlist?list=PL0lo9MOBetEFmtstItnKlhJJVmMghxc0P) stream weekly on GitHub's [YouTube](https://www.youtube.com/@GitHub), [Twitch](https://www.twitch.tv/github), and [LinkedIn](https://www.linkedin.com/company/github).

--- a/content/events/2026-05-27-maintainer-month-special-jeff-luszcz.md
+++ b/content/events/2026-05-27-maintainer-month-special-jeff-luszcz.md
@@ -1,0 +1,16 @@
+---
+title: 'Maintainer Month Special: Jeff Luszcz'
+metaTitle: 'Maintainer Month Special: Jeff Luszcz'
+metaDesc: 'Open source licensing, SBOMs, and supply chain security for maintainers in 2026.'
+date: '05/27'
+UTCStartTime: '20:00'
+UTCEndTime: '21:00'
+type: 'stream'
+language: 'English'
+location: 'Virtual'
+userName: 'GitHub'
+userLink: 'https://github.com/github'
+linkUrl: 'https://www.youtube.com/@GitHub'
+---
+
+Join Jeff Luszcz for a Maintainer Month Special on open source licensing, SBOMs, and supply chain security for maintainers in 2026.

--- a/content/events/2026-05-27-maintainer-month-special-jeff-luszcz.md
+++ b/content/events/2026-05-27-maintainer-month-special-jeff-luszcz.md
@@ -8,9 +8,9 @@ UTCEndTime: '21:00'
 type: 'stream'
 language: 'English'
 location: 'Virtual'
-userName: 'GitHub'
-userLink: 'https://github.com/github'
-linkUrl: 'https://www.youtube.com/@GitHub'
+userName: 'jeffrey-luszcz'
+userLink: 'https://github.com/jeffrey-luszcz'
+linkUrl: 'https://www.youtube.com/watch?v=DxiaRvBuqo8'
 ---
 
 Join Jeff Luszcz for a Maintainer Month Special on open source licensing, SBOMs, and supply chain security for maintainers in 2026.

--- a/content/events/2026-05-29-dlt.md
+++ b/content/events/2026-05-29-dlt.md
@@ -1,0 +1,18 @@
+---
+title: 'Open Source Friday: dlt'
+metaTitle: 'Open Source Friday: dlt'
+metaDesc: 'Vis Kahoro on dlt, a Python SDK for production-grade data pipelines built by developers and agents.'
+date: '05/29'
+UTCStartTime: '17:00'
+UTCEndTime: '18:00'
+type: 'stream'
+language: 'English'
+location: 'Virtual'
+userName: 'GitHub'
+userLink: 'https://github.com/github'
+linkUrl: 'https://www.youtube.com/@GitHub'
+---
+
+Join Vis Kahoro for a look at [dlt](https://github.com/dlt-hub/dlt), a Python SDK for building production-grade data pipelines — designed for both developers and agents.
+
+[Open Source Fridays](https://www.youtube.com/playlist?list=PL0lo9MOBetEFmtstItnKlhJJVmMghxc0P) stream weekly on GitHub's [YouTube](https://www.youtube.com/@GitHub), [Twitch](https://www.twitch.tv/github), and [LinkedIn](https://www.linkedin.com/company/github).


### PR DESCRIPTION
Adds 5 OSF and Maintainer Month Special events for May 2026:

| Date | Time (ET) | Event |
|------|-----------|-------|
| Fri, May 8 | 1 PM | Open Source Friday: Spec Kit — Den Delimarsky (@localden) |
| Fri, May 22 | 12 PM | Maintainer Month Panel: Age Assurance Laws and Open Source |
| Fri, May 22 | 1 PM | Open Source Friday: OpenMind (OM1) — Prachi Sethi |
| Wed, May 27 | 4 PM | Maintainer Month Special: Jeff Luszcz |
| Fri, May 29 | 1 PM | Open Source Friday: dlt — Vis Kahoro |

> **Note:** All `linkUrl` fields currently point to `https://www.youtube.com/@GitHub` — please update with specific stream/video URLs when available.