### PR TITLE
Show Render as visible card on Partner Pack

### DIFF
--- a/content/partner-pack/offers/render.md
+++ b/content/partner-pack/offers/render.md
@@ -3,6 +3,6 @@ name: "Render"
 logo: "render.png"
 headline: "Cloud credits for open source maintainers."
 description: "Render is offering cloud credits for open source maintainers. Details available in the private Maintainer Community."
-ctaText: "Join the Maintainer Community"
-ctaLink: "https://maintainers.github.com"
+ctaText: "View in Maintainer Community"
+ctaLink: "https://github.com/community/maintainers/discussions/768"
 ---

--- a/content/partner-pack/offers/render.md
+++ b/content/partner-pack/offers/render.md
@@ -3,8 +3,6 @@ name: "Render"
 logo: "render.png"
 headline: "Cloud credits for open source maintainers."
 description: "Render is offering cloud credits for open source maintainers. Details available in the private Maintainer Community."
-secondaryCta: "(Available to members of the private Maintainer Community)"
 ctaText: "Join the Maintainer Community"
 ctaLink: "https://maintainers.github.com"
-private: true
 ---


### PR DESCRIPTION
Removes private flag. Render shows as a card with CTA linking to the Maintainer Community. No offer specifics on the public page.