### PR TITLE
Add 'Add to Calendar' links to event detail pages

### DIFF
--- a/components/event-detail/EventDetail.jsx
+++ b/components/event-detail/EventDetail.jsx
@@ -14,6 +14,62 @@ import DateTimeChip from '../date-time-chip/DateTimeChip'
 import Chip from '../chip/Chip'
 import PlayLink from '../play-link/PlayLink'
 
+
+const CURRENT_YEAR = 2026
+
+const buildCalendarDate = (dateStr, timeStr) => {
+  if (!dateStr || !timeStr || timeStr === 'TBD') return null
+  const [month, day] = dateStr.split('/')
+  const [hour, minute] = timeStr.split(':')
+  const d = new Date(Date.UTC(CURRENT_YEAR, parseInt(month) - 1, parseInt(day), parseInt(hour), parseInt(minute)))
+  return d.toISOString().replace(/[-:]/g, '').replace('.000', '').replace(/\.\d{3}/, '')
+}
+
+const getGoogleCalendarUrl = (event) => {
+  const start = buildCalendarDate(event.date, event.UTCStartTime)
+  const end = buildCalendarDate(event.endDate || event.date, event.UTCEndTime)
+  if (!start || !end) return null
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    dates: `${start}/${end}`,
+    details: event.content ? event.content.substring(0, 500) : '',
+    location: event.location || '',
+  })
+  if (event.linkUrl) params.set('details', `${event.linkUrl}\n\n${params.get('details')}`)
+  return `https://calendar.google.com/calendar/render?${params.toString()}`
+}
+
+const getIcsContent = (event) => {
+  const start = buildCalendarDate(event.date, event.UTCStartTime)
+  const end = buildCalendarDate(event.endDate || event.date, event.UTCEndTime)
+  if (!start || !end) return null
+  const description = event.linkUrl ? `${event.linkUrl}\n\n${(event.content || '').substring(0, 500)}` : (event.content || '').substring(0, 500)
+  return `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+DTSTART:${start}
+DTEND:${end}
+SUMMARY:${event.title}
+DESCRIPTION:${description.replace(/\n/g, '\\n')}
+LOCATION:${event.location || ''}
+URL:${event.linkUrl || ''}
+END:VEVENT
+END:VCALENDAR`
+}
+
+const downloadIcs = (event) => {
+  const ics = getIcsContent(event)
+  if (!ics) return
+  const blob = new Blob([ics], { type: 'text/calendar;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${event.title.replace(/[^a-zA-Z0-9]/g, '-')}.ics`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
 const EventDetail = ({ event, reverseColumns, isFullPage }) => {
   const { setAnimationStep } = useBackground()
 
@@ -95,6 +151,27 @@ const EventDetail = ({ event, reverseColumns, isFullPage }) => {
           >
             {getLiteral(`event-button:${event.type}`)} <IconArrowRight />
           </a>
+          <div className="event-detail__calendar-links">
+            {getGoogleCalendarUrl(event) && (
+              <a
+                className="event-detail__calendar-link"
+                href={getGoogleCalendarUrl(event)}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Add to Google Calendar
+              </a>
+            )}
+            {getIcsContent(event) && (
+              <button
+                className="event-detail__calendar-link"
+                onClick={() => downloadIcs(event)}
+                type="button"
+              >
+                Download .ics
+              </button>
+            )}
+          </div>
         </div>
       ) : null}
     </article>

--- a/components/event-detail/EventDetail.jsx
+++ b/components/event-detail/EventDetail.jsx
@@ -17,11 +17,15 @@ import PlayLink from '../play-link/PlayLink'
 
 const CURRENT_YEAR = 2026
 
+const isTBDOrAllDay = (val) => !val || val === 'TBD' || val.toLowerCase().replace(/[\s\-_]/g, '') === 'allday'
+
 const buildCalendarDate = (dateStr, timeStr) => {
-  if (!dateStr || !timeStr || timeStr === 'TBD') return null
+  if (!dateStr || isTBDOrAllDay(timeStr)) return null
   const [month, day] = dateStr.split('/')
   const [hour, minute] = timeStr.split(':')
+  if (isNaN(hour) || isNaN(minute)) return null
   const d = new Date(Date.UTC(CURRENT_YEAR, parseInt(month) - 1, parseInt(day), parseInt(hour), parseInt(minute)))
+  if (isNaN(d.getTime())) return null
   return d.toISOString().replace(/[-:]/g, '').replace('.000', '').replace(/\.\d{3}/, '')
 }
 

--- a/components/event-detail/event-detail.scss
+++ b/components/event-detail/event-detail.scss
@@ -291,3 +291,23 @@
     }
   }
 }
+.event-detail__calendar-links {
+  display: flex;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.event-detail__calendar-link {
+  font-size: 14px;
+  color: var(--color-fg-muted, #656d76);
+  text-decoration: underline;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+
+  &:hover {
+    color: var(--color-fg-default, #1f2328);
+  }
+}


### PR DESCRIPTION
Adds Google Calendar and .ics download links to every event detail page.

- Google Calendar link opens pre-filled event in Google Calendar
- .ics download works for Outlook, Apple Calendar, and other calendar apps
- Only shows when the event has specific start/end times (not TBD)
- Links appear below the event action button on the full page view