### PR TITLE
Show Partner Pack tab in navigation

### DIFF
--- a/components/header/Header.jsx
+++ b/components/header/Header.jsx
@@ -66,7 +66,6 @@ const Header = () => {
 
         <nav className="header__navigation" aria-label="Main navigation">
           <ul className="header__list">
-            {/* Partner Pack tab hidden until launch */}
             <li>
               <Link
                 href={ROUTES.SHIPS.getPath(year)}
@@ -106,6 +105,20 @@ const Header = () => {
                 <IconBooks />
                 <span className="header__link-text">
                   {getLiteral('navigation:library')}
+                </span>
+              </Link>
+            </li>
+            <li>
+              <Link
+                href={ROUTES.PARTNER_PACK.getPath(year)}
+                aria-label={getLiteral('navigation:partner-pack')}
+                className={clsx('header__link', {
+                  ['is-active']: pathname === ROUTES.PARTNER_PACK.getPath(year),
+                })}
+              >
+                <BoxGift />
+                <span className="header__link-text">
+                  {getLiteral('navigation:partner-pack')}
                 </span>
               </Link>
             </li>


### PR DESCRIPTION
Adds the Partner Pack tab back to the header navigation, after Library. Order: Ships > Schedule > Library > Partner Pack.