### PR TITLE
Tighten header nav spacing for 4-tab layout

### DIFF
--- a/components/header/header.scss
+++ b/components/header/header.scss
@@ -83,14 +83,14 @@
 
   &__list {
     display: flex;
-    column-gap: spacing(1);
+    column-gap: spacing(0.5);
 
     @media (min-width: $md) {
-      column-gap: spacing(2);
+      column-gap: spacing(1);
     }
 
     @media (min-width: $lg) {
-      column-gap: spacing(4);
+      column-gap: spacing(2);
     }
   }
 
@@ -110,7 +110,7 @@
 
     @media (min-width: $lg) {
       width: auto;
-      padding: 0 spacing(2);
+      padding: 0 spacing(1.5);
     }
 
     &.is-active {


### PR DESCRIPTION
Reduces gap between nav tabs and link padding now that we have 4 tabs (Ships, Schedule, Library, Partner Pack) instead of 3. The previous `spacing(4)` (32px) gaps at desktop were too wide with the extra tab.

Changes:
- column-gap: spacing(4) -> spacing(2) at lg breakpoint
- column-gap: spacing(2) -> spacing(1) at md breakpoint  
- column-gap: spacing(1) -> spacing(0.5) at base
- link padding: spacing(2) -> spacing(1.5) at lg breakpoint