### PR TITLE
Footer: add git blame link and dev console hint

### DIFF
--- a/components/footer/Footer.jsx
+++ b/components/footer/Footer.jsx
@@ -22,6 +22,10 @@ const Footer = () => {
 
   const classes = clsx('footer', { 'is-home': isHome })
 
+  if (typeof window !== 'undefined') {
+    console.log('%c git blame %c https://gh.io/maintainer-tea', 'background:#1a1a1a;color:#d4a017;padding:2px 6px;font-weight:bold', 'color:#888')
+  }
+
   return (
     <footer className={classes} role="contentinfo">
       <div className="footer__copyright">
@@ -32,6 +36,16 @@ const Footer = () => {
           rel="noreferrer"
         >
           {getLiteral('footer:repository-title')}
+        </a>
+        <span className="footer__divider" />
+
+        <a
+          className="footer__link footer__blame"
+          href="https://gh.io/maintainer-tea"
+          target="_blank"
+          rel="noreferrer"
+        >
+          git blame
         </a>
         <span className="footer__divider" />
 

--- a/components/footer/footer.scss
+++ b/components/footer/footer.scss
@@ -157,4 +157,11 @@
       }
     }
   }
+
+  &__blame {
+    opacity: 0.4;
+    font-family: monospace;
+    font-size: 11px;
+    letter-spacing: 0.5px;
+  }
 }


### PR DESCRIPTION
Adds a small monospace `git blame` link to the footer copyright area and a styled console.log message for developers who open DevTools.

Matches the existing footer link style but at reduced opacity.