### PR TITLE
Reorder library: move fresh items to the top

### DIFF
--- a/content/library/resources.json
+++ b/content/library/resources.json
@@ -1,6 +1,70 @@
 {
     "resources": [
         {
+            "title": "Maintainers in Academia",
+            "author": "Academia Maintainers",
+            "description": "Maintainer stories from researchers and educators building open source in universities and institutions around the world.",
+            "link": "https://maintainermonth.github.com/academia",
+            "type": "Interviews",
+            "topics": "Various Projects"
+        },
+        {
+            "title": "Maintainer Maintainers",
+            "author": "The Changelog Podcast",
+            "description": "Stormy Peters, Dr. Dawn Foster, and Angie Byron discuss the challenges and rewards of maintaining maintainers.",
+            "link": "https://changelog.com/podcast/542",
+            "type": "Podcast",
+            "topics": "Maintainer Journey"
+        },
+        {
+            "title": "Maintaining the Bluesky MCP Server",
+            "author": "host @EbonyLouis, guest Brian Ellin",
+            "description": "A conversation between Ebony Louis and Brian Ellin on building and maintaining the Bluesky MCP server—and what it takes to build with open protocols.",
+            "link": "https://www.youtube.com/watch?v=G8DEF_xCUfs",
+            "type": "Livestream VOD",
+            "topics": "AI agent, MCP, open source"
+        },
+        {
+            "title": "How We Built the Confluence MCP Server",
+            "author": "Rizel Scarlett @blackgirlbytes",
+            "description": "Rizel Scarlett speaks with Sean Falconer and Edward V., maintainers of the Confluence MCP server, about building it and how it democratizes real-time data streaming.",
+            "link": "https://www.youtube.com/watch?v=ivlzvZzFeZM",
+            "type": "Livestream VOD",
+            "topics": "AI agent, MCP server, goose, confluence"
+        },
+        {
+            "title": "Collaborative Maintainership in Motion: Improving the mbot MCP Server",
+            "author": "Ian Douglas @iandouglas",
+            "description": "To help an AI agent drive a robot, contributor Ian Douglas became a maintainer by extending an existing MCP server—highlighting the power of shared ownership and open source collaboration.",
+            "link": "https://block.github.io/goose/blog/2025/05/20/goose-gets-a-drivers-license/",
+            "type": "Blog",
+            "topics": "AI agent, MCP server, robot, open source"
+        },
+        {
+            "title": "What It Takes to Maintain Local AI: Goose + Qwen3",
+            "author": "Mic Neale @michaelneale",
+            "description": "Mic Neale shares his perspective as a maintainer on building tools that respect developer autonomy while building local-first AI tools.",
+            "link": "https://block.github.io/goose/blog/2025/05/12/local-goose-qwen3/",
+            "type": "Blog",
+            "topics": "AI agent, open source"
+        },
+        {
+            "title": "Swastik Baranwal Open Source Journey",
+            "author": "Swastik Baranwal",
+            "description": "Hear about Swastik Baranwal's open source story through the Open Source Initiative (OSI), where he tells his story and how he inspires new people to get involved in open source.",
+            "link": "https://opensource.org/maintainers/delta456",
+            "type": "Blog",
+            "topics": "open source, story, maintainer"
+        },
+        {
+            "title": "Scaling Security: Inside the GitHub Securing Open Source Software Fund",
+            "author": "OpenSSF",
+            "description": "In this episode of What’s in the SOSS?, CRob sits down with Kevin Crosby and Xavier René-Corail from GitHub to unpack the GitHub Secure Open Source (SOS) Fund.",
+            "link": "https://openssf.org/podcast/2025/05/13/whats-in-the-soss-podcast-30-s2e07-scaling-security-inside-the-github-securing-open-source-software-fund/",
+            "type": "Podcast",
+            "topics": "open source, security, funding"
+        },
+        {
             "title": "The Changelog Podcast",
             "author": "Changelog",
             "description": "A podcast discussing the latest in open source, software development, and the people behind it.",
@@ -193,14 +257,6 @@
             "topics": "Maintainer Month"
         },
         {
-            "title": "Maintainers in Academia",
-            "author": "Academia Maintainers",
-            "description": "Maintainer stories from researchers and educators building open source in universities and institutions around the world.",
-            "link": "https://maintainermonth.github.com/academia",
-            "type": "Interviews",
-            "topics": "Various Projects"
-        },
-        {
             "title": "Ed Warnicke",
             "author": "Open at Microsoft",
             "description": "An introduction to OmniBOR and how it benefits open source projects.",
@@ -215,62 +271,6 @@
             "link": "https://surrealdb.com/blog/maintainer-month-2023-behind-the-scenes-with-yusuke-kuoka",
             "type": "Blog",
             "topics": "SurrealDB"
-        },
-        {
-            "title": "Maintainer Maintainers",
-            "author": "The Changelog Podcast",
-            "description": "Stormy Peters, Dr. Dawn Foster, and Angie Byron discuss the challenges and rewards of maintaining maintainers.",
-            "link": "https://changelog.com/podcast/542",
-            "type": "Podcast",
-            "topics": "Maintainer Journey"
-        },
-        {
-            "title": "Maintaining the Bluesky MCP Server",
-            "author": "host @EbonyLouis, guest Brian Ellin",
-            "description": "A conversation between Ebony Louis and Brian Ellin on building and maintaining the Bluesky MCP server—and what it takes to build with open protocols.",
-            "link": "https://www.youtube.com/watch?v=G8DEF_xCUfs",
-            "type": "Livestream VOD",
-            "topics": "AI agent, MCP, open source"
-        },
-        {
-            "title": "How We Built the Confluence MCP Server",
-            "author": "Rizel Scarlett @blackgirlbytes",
-            "description": "Rizel Scarlett speaks with Sean Falconer and Edward V., maintainers of the Confluence MCP server, about building it and how it democratizes real-time data streaming.",
-            "link": "https://www.youtube.com/watch?v=ivlzvZzFeZM",
-            "type": "Livestream VOD",
-            "topics": "AI agent, MCP server, goose, confluence"
-        },
-        {
-            "title": "Collaborative Maintainership in Motion: Improving the mbot MCP Server",
-            "author": "Ian Douglas @iandouglas",
-            "description": "To help an AI agent drive a robot, contributor Ian Douglas became a maintainer by extending an existing MCP server—highlighting the power of shared ownership and open source collaboration.",
-            "link": "https://block.github.io/goose/blog/2025/05/20/goose-gets-a-drivers-license/",
-            "type": "Blog",
-            "topics": "AI agent, MCP server, robot, open source"
-        },
-        {
-            "title": "What It Takes to Maintain Local AI: Goose + Qwen3",
-            "author": "Mic Neale @michaelneale",
-            "description": "Mic Neale shares his perspective as a maintainer on building tools that respect developer autonomy while building local-first AI tools.",
-            "link": "https://block.github.io/goose/blog/2025/05/12/local-goose-qwen3/",
-            "type": "Blog",
-            "topics": "AI agent, open source"
-        },
-        {
-            "title": "Swastik Baranwal Open Source Journey",
-            "author": "Swastik Baranwal",
-            "description": "Hear about Swastik Baranwal's open source story through the Open Source Initiative (OSI), where he tells his story and how he inspires new people to get involved in open source.",
-            "link": "https://opensource.org/maintainers/delta456",
-            "type": "blog",
-            "topics": "open source, story, maintainer"
-        },
-        {
-            "title": "Scaling Security: Inside the GitHub Securing Open Source Software Fund",
-            "author": "OpenSSF",
-            "description": "In this episode of What’s in the SOSS?, CRob sits down with Kevin Crosby and Xavier René-Corail from GitHub to unpack the GitHub Secure Open Source (SOS) Fund.",
-            "link": "https://openssf.org/podcast/2025/05/13/whats-in-the-soss-podcast-30-s2e07-scaling-security-inside-the-github-securing-open-source-software-fund/",
-            "type": "podcast",
-            "topics": "open source, security, funding"
         }
     ]
 }


### PR DESCRIPTION
Moves the 8 newest 2025 resources to the top of the library page so visitors see fresh content first:

- Maintainers in Academia
- Maintainer Maintainers
- Maintaining the Bluesky MCP Server
- How We Built the Confluence MCP Server
- Collaborative Maintainership in Motion (mbot MCP)
- What It Takes to Maintain Local AI (Goose + Qwen3)
- Swastik Baranwal Open Source Journey
- Scaling Security (OpenSSF)

Also fixes inconsistent `type` casing (`blog` → `Blog`, `podcast` → `Podcast`).