### PR TITLE
Fix organizer for AT hackathon event

### DIFF
--- a/content/events/2026-05-21-open-source-assistive-technology-hackathon-issue-385.md
+++ b/content/events/2026-05-21-open-source-assistive-technology-hackathon-issue-385.md
@@ -8,7 +8,7 @@ date: 05/21
 type: misc
 language: English
 location: 'San Francisco, CA'
-userName: Maria Lamardo
+userName: GitHub
 endDate: 05/22
 UTCStartTime: '09:00'
 UTCEndTime: '07:00'


### PR DESCRIPTION
Changes the organizer for the Open Source Assistive Technology Hackathon from 'Maria Lamardo' to 'GitHub'.