### PR TITLE
Shorten product name in Ref.tools description

### DIFF
--- a/content/partner-pack/offers/reftools.md
+++ b/content/partner-pack/offers/reftools.md
@@ -2,7 +2,7 @@
 name: "Ref.tools"
 logo: "reftools.png"
 headline: "2 months free for open source maintainers."
-description: "Get 2 months of free access to Ref.tools Basic or Pro — the planning layer for human and agent software teams."
+description: "Get 2 months of free access to Ref Basic or Pro — the planning layer for human and agent software teams."
 secondaryCta: "Use code: MAINTAINER2026"
 ctaText: "Get started"
 ctaLink: "https://ref.tools/"


### PR DESCRIPTION
Updated the description to shorten the product name as per Partner to remove the ".tools"

Get 2 months of free access to Ref.tools Basic or Pro — the planning...

to

Get 2 months of free access to Ref Basic or Pro — the planning...