### PR TITLE
Update Radix .tech domain claim link

### DIFF
--- a/content/partner-pack/offers/radix.md
+++ b/content/partner-pack/offers/radix.md
@@ -4,5 +4,5 @@ logo: "radix.png"
 headline: "Free 1-year .tech domain for maintainers."
 description: "Claim a free 1-year .tech domain to give your open source project a home on the web."
 ctaText: "Claim domain"
-ctaLink: "https://get.tech/"
+ctaLink: "https://forms.cloud.microsoft/Pages/ResponsePage.aspx?id=VGaKOXuZ6UexK5UVuJa03teeUFjH6lpKpYGcfc-HsrBUNTRaWVRKTVpTQU1HVzBTUUdLUk41Tk9NNi4u"
 ---


### PR DESCRIPTION
Points the Radix offer CTA to the Microsoft Forms claim form instead of the generic get.tech landing page.