### PR TITLE
Update Datadog COSE event

### DIFF
--- a/content/events/2026-05-26-open-source-engineering-at-datadog-issue-451.md
+++ b/content/events/2026-05-26-open-source-engineering-at-datadog-issue-451.md
@@ -2,7 +2,7 @@
 title: Open Source Engineering at Datadog
 metaTitle: Open Source Engineering at Datadog
 metaDesc: >-
-  ​Join Datadog's Core Open Source Engineering (COSE) team at our NYC office for
+  ​Join Datadog's Community Open Source Engineering (COSE) team at our NYC office for
   a GitHub Maintainer Month evening on two major open source observability
   proje...
 date: 05/26
@@ -16,13 +16,17 @@ UTCEndTime: '20:30'
 userLink: 'https://www.datadoghq.com/'
 linkUrl: 'https://luma.com/zqa5nphu'
 ---
-​Join Datadog's Core Open Source Engineering (COSE) team at our NYC office for a GitHub Maintainer Month evening on two major open source observability projects we maintain: Vector and Quickwit. Expect a short intro to the Community Open Source Engineering team, talks and demos on each project, food, drinks, and networking.
+​Join Datadog's Community Open Source Engineering (COSE) team at our NYC office for a GitHub Maintainer Month evening on two major open source observability projects we maintain: Vector and Quickwit. Expect a short intro to the Community Open Source Engineering team, talks and demos on each project, food, drinks, and networking.
 
 ​Open to NYC's open source and observability community.
 
 Agenda:
 6:00pm - Arrivals, networking, food and drinks provided by Datadog
+
 6:40pm - Welcome remarks
+
 6:45 - Vector: One Agent to Rule Them All? - Pavlos Rontidis, Senior Software Engineer at COSE 
+
 7:10 - Quickwit: Search and analytics engine for logs - Adrien Guillo, Staff Engineer
+
 7:30 - Networking


### PR DESCRIPTION
Replacement for #455 from an upstream branch so CodeQL can run under the org ruleset. Preserves Arielle as commit author.