### PR TITLE
Add NOSS organizer link

### DIFF
--- a/content/events/2026-05-30-nosso-open-source-summit-issue-420.md
+++ b/content/events/2026-05-30-nosso-open-source-summit-issue-420.md
@@ -7,6 +7,7 @@ type: conference
 language: Portuguese
 location: Virtual
 userName: Cumbuca Dev
+userLink: 'https://github.com/cumbucadev'
 endDate: 05/30
 UTCStartTime: '12:30'
 UTCEndTime: '21:30'


### PR DESCRIPTION
Replacement for #465 from an upstream branch so CodeQL can run under the org ruleset. Preserves Nick Vidal as commit author.