### PR TITLE
Fix Open Source Founders Summit organizer

### DIFF
--- a/content/events/2026-05-18-open-source-founders-summit-issue-463.md
+++ b/content/events/2026-05-18-open-source-founders-summit-issue-463.md
@@ -9,7 +9,7 @@ date: 05/18
 type: conference
 language: English
 location: 'Paris, France'
-userName: Emily Omier
+userName: 05F5
 endDate: 05/19
 UTCStartTime: '07:00'
 UTCEndTime: '15:00'


### PR DESCRIPTION
Updates the Open Source Founders Summit schedule listing to use the organizer name 05F5 instead of the submitter name.

This matches the 2025 listing and reads better on the public schedule.