### PR TITLE
Update cities for Web Summit

### DIFF
--- a/content/partner-pack/offers/websummit.md
+++ b/content/partner-pack/offers/websummit.md
@@ -2,7 +2,7 @@
 name: "Web Summit"
 logo: "websummit.png"
 headline: "Connect with global tech leaders."
-description: "Get discounted tickets to Web Summit Vancouver and Lisbon through their Developer Program — plus access to workshops and community events for open source contributors."
+description: "Get discounted tickets to Web Summit Rio and Lisbon through their Developer Program — plus access to workshops and community events for open source contributors."
 ctaText: "Get tickets"
 ctaLink: "https://cilabs-sysops.formstack.com/forms/lis26_github_maintainer_month?utm_source=Community&utm_medium=email"
 ---


### PR DESCRIPTION
The form has a choice between Rio and Lisbon, not Vancouver and Lisbon:

<img width="696" height="164" alt="image" src="https://github.com/user-attachments/assets/f0a6fa73-be6c-48e4-a544-c28e5f8a6aa7" />
