### PR TITLE
Update Web Summit partner pack offer with new copy and corrected cities

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,4 +1,5 @@
 name: build-and-deploy
+# Triggers CodeQL Actions analysis (org policy)
 on:
   push:
     branches:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,5 +1,4 @@
 name: build-and-deploy
-# Triggers CodeQL Actions analysis (org policy)
 on:
   push:
     branches:

--- a/content/partner-pack/offers/websummit.md
+++ b/content/partner-pack/offers/websummit.md
@@ -1,8 +1,8 @@
 ---
 name: "Web Summit"
 logo: "websummit.png"
-headline: "Connect with global tech leaders."
-description: "Get discounted tickets to Web Summit Vancouver and Lisbon through their Developer Program — plus access to workshops and community events for open source contributors."
+headline: "Free tickets for open source maintainers"
+description: "Web Summit runs the world's largest technology events, connecting people and ideas that change the world. Get a free ticket to Web Summit in either Rio de Janeiro or Lisbon this year as a thank you for your contributions."
 ctaText: "Get tickets"
 ctaLink: "https://cilabs-sysops.formstack.com/forms/lis26_github_maintainer_month?utm_source=Community&utm_medium=email"
 ---


### PR DESCRIPTION
Updates the Web Summit entry in the partner pack:

- **Headline** is now "Free tickets for open source maintainers"
- **Description** uses Web Summit's updated copy and reflects that tickets are free (not discounted)
- **Cities** are Rio de Janeiro and Lisbon (the actual options on the form), correcting the prior "Vancouver and Lisbon"

Form already lives at the existing CTA link.

Supersedes #476 — credit to @hugovk for catching the city mismatch. Folded that fix in here so the offer ships with one PR.

/cc @cassidoo @AndreaGriffiths11 @LadyKerr