### PR TITLE
Update Web Summit partner pack offer

### DIFF
--- a/content/partner-pack/offers/websummit.md
+++ b/content/partner-pack/offers/websummit.md
@@ -1,8 +1,8 @@
 ---
 name: "Web Summit"
 logo: "websummit.png"
-headline: "Connect with global tech leaders."
-description: "Get discounted tickets to Web Summit Vancouver and Lisbon through their Developer Program — plus access to workshops and community events for open source contributors."
+headline: "Free tickets for open source maintainers"
+description: "Web Summit runs the world's largest technology events, connecting people and ideas that change the world. Get a free ticket to Web Summit in either Rio de Janeiro or Lisbon this year as a thank you for your contributions."
 ctaText: "Get tickets"
 ctaLink: "https://cilabs-sysops.formstack.com/forms/lis26_github_maintainer_month?utm_source=Community&utm_medium=email"
 ---


### PR DESCRIPTION
Updates the Web Summit entry in the partner pack:

- Headline is now "Free tickets for open source maintainers"
- Description uses Web Summit's updated copy and reflects that tickets are free, not discounted
- Cities are Rio de Janeiro and Lisbon, matching the options on the form

Supersedes #477, recreated from an upstream branch so CodeQL can run under the org ruleset.