### PR TITLE
Fix OSSNA 2026 location to Minneapolis

### DIFF
--- a/content/events/2026-05-18-open-source-summit-north-america.md
+++ b/content/events/2026-05-18-open-source-summit-north-america.md
@@ -8,7 +8,7 @@ metaDesc: >-
 date: 05/18
 type: conference
 language: English
-location: 'Denver, CO, USA'
+location: 'Minneapolis, MN, USA'
 userName: GitHub
 endDate: 05/20
 UTCStartTime: all-day


### PR DESCRIPTION
Updates the Open Source Summit North America event location from Denver, CO to Minneapolis, MN.

OSSNA 2026 is in Minneapolis: https://events.linuxfoundation.org/open-source-summit-north-america/