### PR TITLE
Add Linux Foundation OSSNA partner offer

### DIFF
--- a/content/partner-pack/offers/linuxfoundation.md
+++ b/content/partner-pack/offers/linuxfoundation.md
@@ -1,0 +1,9 @@
+---
+name: "Linux Foundation"
+logo: "linuxfoundation.png"
+headline: "Free tickets to Open Source Summit North America"
+description: "The Linux Foundation is offering 5 free passes to Open Source Summit North America in Minneapolis, May 18-20, for open source maintainers. First come, first served."
+secondaryCta: "Email maintainermonth@github.com with the subject 'OSSNA maintainer pass' to claim one"
+ctaText: "Learn more"
+ctaLink: "https://events.linuxfoundation.org/open-source-summit-north-america/"
+---


### PR DESCRIPTION
Adds the Linux Foundation Open Source Summit North America offer to the partner pack.

**Offer**: 5 free passes to OSSNA (Minneapolis, May 18-20) for open source maintainers. First come, first served — claimed by emailing maintainermonth@github.com.

**Pattern**: Follows the Arachne offer structure — `ctaLink` to the event marketing page, `secondaryCta` for the email claim instruction.

**Logo**: `linuxfoundation.png` already exists in `public/images/partners/`.

Replaces #482 (which was opened from a fork; CodeQL doesn't run on fork PRs and the org ruleset requires it).