### PR TITLE
Tighten LF offer copy and fix long-email overflow

### DIFF
--- a/components/partner-pack/offers/offers.scss
+++ b/components/partner-pack/offers/offers.scss
@@ -75,6 +75,7 @@
       font-size: 1rem; // Back to normal size
       line-height: 1.5;
       color: rgba(255, 255, 255, 0.75);
+      overflow-wrap: anywhere;
       
       strong {
         color: rgba(255, 255, 255, 0.9);

--- a/content/partner-pack/offers/linuxfoundation.md
+++ b/content/partner-pack/offers/linuxfoundation.md
@@ -1,9 +1,9 @@
 ---
 name: "Linux Foundation"
 logo: "linuxfoundation.png"
-headline: "Free tickets to Open Source Summit North America"
-description: "The Linux Foundation is offering 5 free passes to Open Source Summit North America in Minneapolis, May 18-20, for open source maintainers. First come, first served."
-secondaryCta: "Email maintainermonth@github.com with the subject 'OSSNA maintainer pass' to claim one"
+headline: "5 free OSSNA passes for maintainers."
+description: "Open Source Summit North America. Minneapolis, May 18-20. First come, first served."
+secondaryCta: "Email maintainermonth@github.com to claim a pass."
 ctaText: "Learn more"
 ctaLink: "https://events.linuxfoundation.org/open-source-summit-north-america/"
 ---


### PR DESCRIPTION
Follow-up to #483.

**Copy**: Trim the LF offer to match the length and rhythm of Daytona, Web Summit, etc. Headline now leads with the value (`5 free OSSNA passes for maintainers`). Description is two short sentences. Email CTA drops the subject-line instruction.

**CSS**: Add `overflow-wrap: anywhere` to `.offer-card__description p` so long emails and codes wrap inside the card instead of getting clipped at narrow widths (the LF email was getting cut off at `maintainermonth@github.cor`). Also benefits Daytona's long promo code.