### PR TITLE
Update linkUrl and userLink for 2026-05-31 event

### DIFF
--- a/content/events/2026-05-31-how-to-be-the-contributor-maintainers-actually-want-issue-489.md
+++ b/content/events/2026-05-31-how-to-be-the-contributor-maintainers-actually-want-issue-489.md
@@ -13,8 +13,8 @@ type: talk
 language: English
 location: Virtual
 userName: Ayushman Bhattacharya
-userLink: 'https://gdg.community.dev/gdg-on-campus-jis-university-kolkata-india/'
-linkUrl: 'https://gdg.community.dev/gdg-on-campus-jis-university-kolkata-india/'
+userLink: 'https://github.com/Circuit-Overtime'
+linkUrl: 'https://gdg.community.dev/e/mnntys/'
 ---
 
 **The pitch:** Every student wants to "contribute to open source." Almost nobody thinks about what it looks like from the other side of the PR. I'm a maintainer at [pollinations.ai](https://github.com/pollinations/pollinations) — a free, open generative AI platform — and in this 30-minute talk I'll show what 30 seconds of contributor effort can save a maintainer 30 minutes of work, with concrete examples from our repo.


### PR DESCRIPTION
Re-creates #495 from a local branch so code scanning checks run against the head ref (they don't run on fork-based PRs, which is why #495 was stuck in BLOCKED state despite an approval and a green test run).

Same diff as # updates `userLink` and `linkUrl` on the 2026-05-31 talk by @Circuit-Overtime.495 

Closes #495

Co-authored-by: Ayushman Bhattacharya @Circuit-Overtime