### PR TITLE
Add event: OSPO Alliance  Setting up an institutional OSPO

### DIFF
--- a/content/events/2026-05-29-ospo-alliance-onramp-topic-setting-up-an-institutional-ospo-issue-487.md
+++ b/content/events/2026-05-29-ospo-alliance-onramp-topic-setting-up-an-institutional-ospo-issue-487.md
@@ -1,0 +1,23 @@
+---
+title: 'OSPO Alliance OnRamp - Topic: Setting up an institutional OSPO'
+metaTitle: 'OSPO Alliance OnRamp - Topic: Setting up an institutional OSPO'
+metaDesc: >-
+  Lucie Albaret, Librarian, Guillaume Comparato PhD at [Université Grenoble
+  Alpes] and Violaine Louvet, Research Engineer at the [CNRS’s Jean Kuntzmann
+  Laborat...
+date: 05/29
+type: talk
+language: English
+location: Virtual
+userName: OSPO Alliance
+endDate: 05/29
+UTCStartTime: '08:30'
+UTCEndTime: '10:00'
+userLink: 'https://ospo-alliance.org/onramp/'
+linkUrl: 'https://ospo-alliance.org/resources/onramp/20260529_onramp_calendar.ics'
+---
+Lucie Albaret, Librarian, Guillaume Comparato PhD at [Université Grenoble Alpes] and Violaine Louvet, Research Engineer at the [CNRS’s Jean Kuntzmann Laboratory of Applied Mathematics].
+
+Institutional implementation. Setting up an OSPO: lessons from the field at Grenoble Alpes University.
+
+Research Software is a pillar of research, alongside publications and data. All scientific disciplines are involved in software development, and most of the code produced by research laboratories is open source. For several years now, the Université Grenoble Alpes has been involved, via the Cellule Codes Données Grenoble Alpes, in supporting scientific communities around open source software. This presentation will be given by three individuals representing the expertise needed to support scientific communities in the use of free research software. We will describe the origins of OSPO, its composition and functioning, its activities, and the challenges we face.

--- a/content/events/2026-05-29-ospo-alliance-onramp-topic-setting-up-an-institutional-ospo-issue-487.md
+++ b/content/events/2026-05-29-ospo-alliance-onramp-topic-setting-up-an-institutional-ospo-issue-487.md
@@ -1,10 +1,7 @@
 ---
 title: 'OSPO Alliance OnRamp - Topic: Setting up an institutional OSPO'
 metaTitle: 'OSPO Alliance OnRamp - Topic: Setting up an institutional OSPO'
-metaDesc: >-
-  Lucie Albaret, Librarian, Guillaume Comparato PhD at [Université Grenoble
-  Alpes] and Violaine Louvet, Research Engineer at the [CNRS’s Jean Kuntzmann
-  Laborat...
+metaDesc: 'Lessons from setting up an OSPO at Université Grenoble Alpes: origins, activities, and challenges of supporting open source research software.'
 date: 05/29
 type: talk
 language: English


### PR DESCRIPTION
Adds the calendar entry for the OSPO Alliance OnRamp talk on 2026-05-29 (Setting up an institutional  UniversitOspo Grenoble Alpes / CNRS), submitted by @fredaatz in #487. OnRamp 

Generated locally with `scripts/event-from-issue.js --issue 487` because the auto-publish workflow didn't fire on the issue. Output is byte-identical to what the workflow would have produced.

Validation:
- `npm  41 / 41 passingtest` 
- `npm run  succeedsbuild` 

Closes #487

Co-authored-by: AATZ FREDERIC @fredaatz