### PR TITLE
wrapping up maintainer month 2026 - scheduled for june 1

### DIFF
--- a/components/events-list/EventsList.jsx
+++ b/components/events-list/EventsList.jsx
@@ -48,32 +48,6 @@ const EventsList = ({ events }) => {
           <p className="events-list__subtitle">
             {getLiteral('schedule:description')}
           </p>
-          <div className="events-list__header-actions">
-            <ButtonLink
-              href="https://github.com/github/maintainermonth/issues/new?template=add-to-calendar.yml"
-              isExternal={true}
-              className="events-list__add-button"
-            >
-              {getLiteral('schedule:add-event')}
-            </ButtonLink>
-            <a
-              href="/maintainer-month-2026.ics"
-              download
-              className="events-list__ics-button"
-              aria-label={getLiteral('schedule:ics-label')}
-            >
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 16 16"
-                fill="currentColor"
-                aria-hidden="true"
-              >
-                <path d="M4.75 0a.75.75 0 0 1 .75.75V2h5V.75a.75.75 0 0 1 1.5 0V2H13a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h.75V.75A.75.75 0 0 1 4.75 0ZM3.5 7v6a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5V7h-9Z" />
-              </svg>
-              {getLiteral('schedule:ics-download')}
-            </a>
-          </div>
           <EventFilter
             eventTypes={eventTypeOptions}
             selectedType={selectedType}

--- a/components/header/Header.jsx
+++ b/components/header/Header.jsx
@@ -123,20 +123,6 @@ const Header = () => {
                 </span>
               </Link>
             </li>
-            <li>
-              <Link
-                href={ROUTES.LOVE_LETTERS.path}
-                aria-label="Love Letters"
-                className={clsx('header__link', {
-                  ['is-active']: pathname === ROUTES.LOVE_LETTERS.path,
-                })}
-              >
-                <Heart />
-                <span className="header__link-text">
-                  Love Letters
-                </span>
-              </Link>
-            </li>
           </ul>
         </nav>
       </div>

--- a/components/home/events/Events.jsx
+++ b/components/home/events/Events.jsx
@@ -1,26 +1,11 @@
-import EventDetail from '../../event-detail/EventDetail'
 import SectionDivider from '../../section-divider/SectionDivider'
 import Connection from '../connection/Connection'
 
-import useIncomingEvents from './useIncomingEvents'
-
 const Events = ({ title, list, connectionTitle, connectionButtonText }) => {
-  const events = useIncomingEvents(list)
-
   return (
     <section className="events">
       <div className="events__content">
         <SectionDivider title={title} />
-
-        <div className="events__list">
-          {events.map((event, index) => (
-            <EventDetail
-              key={event.slug}
-              event={event}
-              reverseColumns={index % 2 !== 0}
-            />
-          ))}
-        </div>
       </div>
       <Connection title={connectionTitle} buttonText={connectionButtonText} />
     </section>

--- a/components/home/hero/Hero.jsx
+++ b/components/home/hero/Hero.jsx
@@ -45,8 +45,6 @@ const Hero = ({ date, title, buttonText, buttonLink }) => {
 
           <div className="hero__buttons">
             <ButtonLink href={buttonLink}>{buttonText}</ButtonLink>
-
-            <ButtonLink href={ROUTES.PARTNER_PACK.path}>Get the partner pack</ButtonLink>
           </div>
         </div>
       </div>

--- a/components/partner-pack/offers/Offers.jsx
+++ b/components/partner-pack/offers/Offers.jsx
@@ -65,13 +65,7 @@ const Offers = ({ partnerOffers, additionalSections }) => {
   return (
     <div>
       <h2>Offers</h2>
-      <div className="offers-grid-container">
-        <div className="offers-grid">
-          {publicOffers.map((offer, index) => (
-            <OfferCard key={index} offer={offer} />
-          ))}
-        </div>
-      </div>
+      <p>Thank you for your interest! Maintainer Month 2026 has concluded. Please check back next year for new partner offers and opportunities.</p>
       
       <h2>{wantMoreTitle}</h2>
       <p dangerouslySetInnerHTML={{ __html: wantMoreContent }}></p>

--- a/content/commons.json
+++ b/content/commons.json
@@ -81,7 +81,7 @@
     "ships:filter-all": "All",
 
     "schedule:title": "Schedule",
-    "schedule:description": "List of all events organized during this year's Maintainer Month",
+    "schedule:description": "Thank you all for your amazing activities! Make sure to check out the recordings if available. We look forward to seeing you again next year!",
     "schedule:add-event": "Add your activity",
     "schedule:ics-download": "Subscribe to calendar",
     "schedule:ics-label": "Download .ics file with all Maintainer Month events",

--- a/content/home/1-hero.md
+++ b/content/home/1-hero.md
@@ -1,6 +1,6 @@
 ---
 anchorNavSection: 'Maintainer Month'
 date: 'May 2026'
-title: 'A month for open source maintainers to gather, share, and be celebrated.'
-buttonText: 'See the schedule'
+title: 'Maintainer Month 2026 is a wrap! Thank you for joining us.'
+buttonText: 'See what happened'
 ---

--- a/content/home/2-about.md
+++ b/content/home/2-about.md
@@ -1,6 +1,6 @@
 ---
 anchorNavSection: 'About'
-title: 'Welcome to Maintainer Month!'
+title: 'Thank you for Maintainer Month 2026!'
 ---
 
 Open source runs the world, but who runs open source? Open source maintainers are behind the software we use everyday, but they don't always have the community or support they need. That's why we're celebrating open source maintainers during the month of May.

--- a/content/home/5-events.md
+++ b/content/home/5-events.md
@@ -1,4 +1,4 @@
 ---
 anchorNavSection: 'Schedule'
-title: 'Upcoming events 2026'
+title: 'Maintainer Month 2026 has concluded'
 ---

--- a/content/home/6-connection.md
+++ b/content/home/6-connection.md
@@ -1,5 +1,5 @@
 ---
 anchorNavSection: 'Connection'
-title: 'We have a full month of activities'
+title: 'We had an incredible month of activities'
 buttonText: 'Schedule'
 ---


### PR DESCRIPTION
This pull request updates the Maintainer Month website and related content to reflect the conclusion of Maintainer Month 2026. The changes remove event submission and promotional features, update messaging throughout the site, and revise the event schedule to mark the end of the event. Additionally, the calendar file is updated with new and modified events.

**Key changes:**

**Site messaging and content updates:**

* Updated hero, about, schedule, and connection section titles and descriptions to indicate that Maintainer Month 2026 has concluded and to thank participants.
* Updated the Offers section to display a message that the event has ended and to remove the display of partner offers. 

**Feature and navigation removals:**

* Removed the "Add your activity" button and the calendar download button from the schedule/events list. 
* Removed the "Love Letters" navigation link and the "Get the partner pack" button from the homepage. 
* Removed the events listing from the home events section, reflecting that no upcoming events remain.
