### PR TITLE
Update CODEOWNERS and fix typo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @karasowles, @AndreaGriffiths11, @ladykerr, and @cassidoo will be requested for
+# @AndreaGriffiths11 and @cassidoo will be requested for
 # review when someone opens a pull request.
-*       @karasowles @AndreaGriffiths11 @ladykerr @cassidoo
+*       @AndreaGriffiths11 @cassidoo

--- a/Participation.md
+++ b/Participation.md
@@ -17,7 +17,7 @@ Last year we focused on burnout, a serious issue maintainers frequently face. Th
 Maintainers keep the software ecosystem running, but they’re humans, not machines. Do you know who the maintainers you rely on are? Do you know what kind of support those individuals actually need? Ask what you can do for them, and be ready to listen.
 
 ## How To Get Involved
-Maintainer Month is an open source project — anyone can jump in and contribute! Whether you're a maintainer, an organization, or a fan or open source, you're invited to participate! Here are a few ways you can jump in:
+Maintainer Month is an open source project — anyone can jump in and contribute! Whether you're a maintainer, an organization, or a fan of open source, you're invited to participate! Here are a few ways you can jump in:
 
 ### **For Maintainers:**
 - Share your story

--- a/content/2023/home/4-get-involved.md
+++ b/content/2023/home/4-get-involved.md
@@ -35,4 +35,4 @@ maintainersTitle: "Calling maintainers!"
 partnersTitle: "Interested in Partnering?"
 ---
 
-Maintainer Month is an open source project — anyone can jump in and contribute! Whether you're a maintainer, an organization, or a fan or open source, you're invited to participate! Here are a few ways you can jump in:
+Maintainer Month is an open source project — anyone can jump in and contribute! Whether you're a maintainer, an organization, or a fan of open source, you're invited to participate! Here are a few ways you can jump in:

--- a/content/home/4-get-involved.md
+++ b/content/home/4-get-involved.md
@@ -35,4 +35,4 @@ maintainersTitle: "Calling maintainers!"
 partnersTitle: "Interested in Partnering?"
 ---
 
-Maintainer Month is an open source project — anyone can jump in and contribute! Whether you're a maintainer, an organization, or a fan or open source, you're invited to participate! Here are a few ways you can jump in:
+Maintainer Month is an open source project — anyone can jump in and contribute! Whether you're a maintainer, an organization, or a fan of open source, you're invited to participate! Here are a few ways you can jump in:


### PR DESCRIPTION
This PR removes the former employees from CODEOWNERS and includes the typo fix from PR #502 for the “fan of open source” wording.\n\nSupersedes #502.